### PR TITLE
Add partial Wikidot support

### DIFF
--- a/background.js
+++ b/background.js
@@ -367,6 +367,9 @@ async function main(url, tabId) {
                   case 'doku':
                     searchParams = 'start?do=search&q=' + article;
                     break;
+                  case 'wikidot': // TODO: This won't work for wikidot pages using alternative search components, will need special handling (e.g. SCP Wiki)
+                    searchParams = article;
+                    break;
                 }
                 newURL = 'https://' + site["destination_base_url"] + site["destination_search_path"] + searchParams;
               } else {


### PR DESCRIPTION
Doesn't support wikis using third party search components like the SCP Wiki's Crom. Those will need special support on a case-by-case basis.

Example formatting for a Wikidot wiki using this setup. Note that this particular wiki's search function appears to be offline, however Wikidot wikis all use the same default search page (unless using the aforementioned third party components)
```
  {
    "id": "en-darksouls-fandom",
    "origins_label": "Dark Souls Fandom Wiki",
    "origins": [
      {
        "origin": "Dark Souls Fandom Wiki",
        "origin_base_url": "darksouls.fandom.com",
        "origin_content_path": "/wiki/",
        "origin_main_page": "Dark_Souls_Wiki"
      }
    ],
    "destination": "Dark Souls Wiki",
    "destination_base_url": "darksouls.wikidot.com",
    "destination_platform": "wikidot",
    "destination_icon": "darksouls.png",
    "destination_main_page": "index.php",
    "destination_search_path": "/search:site/q/"
  },
  ```