### PR TITLE
Redirect Azurilland Wiki to Bulbapedia

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1993,13 +1993,19 @@
   },
   {
     "id": "en-pokemon",
-    "origins_label": "Pokémon Fandom Wiki",
+    "origins_label": "Pokémon Fandom Wikis",
     "origins": [
       {
         "origin": "Pokémon Fandom Wiki",
         "origin_base_url": "pokemon.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Pokémon_Wiki"
+      },
+      {
+        "origin": "Azurilland Wiki",
+        "origin_base_url": "pokemon-archive.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Azurilland_Wiki"
       }
     ],
     "destination": "Bulbapedia",


### PR DESCRIPTION
Redirect Azurilland Wiki to Bulbapedia.

Azurilland Wiki was the Gamepedia fork of the Pokémon Wikia. It is now archived.