### PR TITLE
Add Minecraft PC Fandom Wiki to sitesEN.json

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -2118,6 +2118,12 @@
         "origin_base_url": "mcpc.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Minecraft_Wiki"
+      },
+      {
+        "origin": "Minecraft PC Fandom Wiki",
+        "origin_base_url": "minecraftpc.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Welcome_to_the_Minecraft_PC_Wiki"
       }
     ],
     "destination": "Minecraft Wiki",


### PR DESCRIPTION
This doesn't seem to be a terribly active Fandom wiki, but it showed up in Google results for "minecraft sunflower" and "minecraft poppy" so I figured I'd add it