### PR TITLE
Correct capitalization of WiKirby

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1850,7 +1850,7 @@
         "origin_main_page": "Kirby_Wiki"
       }
     ],
-    "destination": "Wikirby",
+    "destination": "WiKirby",
     "destination_base_url": "wikirby.com",
     "destination_platform": "mediawiki",
     "destination_icon": "wikirby.png",


### PR DESCRIPTION
WiKirby was incorrectly capitalized as Wikirby. I've corrected the capitalization in `sitesEN.json`.