### PR TITLE
Add Minecraft Bedrock Fandom Wiki to sitesEN.json

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -2349,6 +2349,12 @@
         "origin_base_url": "minecraftpc.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Welcome_to_the_Minecraft_PC_Wiki"
+      },
+      {
+        "origin": "Minecraft Bedrock Fandom Wiki",
+        "origin_base_url": "minecraftbedrock-archive.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Minecraft_Bedrock_Wiki"
       }
     ],
     "destination": "Minecraft Wiki",


### PR DESCRIPTION
Inactive, but shows up in Google results