### PR TITLE
Improve DokuWiki support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Entries are formatted as follows:
 * `destination`: Name of the wiki being redirected to.
 * `destination_base_url`: Fully qualified domain name of the wiki being redirected to.
 * `destination_content_prefix`: A prefix that is prepended to article names before performing a search on the destination wiki. This can be useful if a wiki separates its content into different namespaces. For example, if we wanted to redirect a wiki about Super Mario Odyssey to a general Mario wiki that has Odyssey content in a namespace called `Odyssey`, we would set `destination_content_prefix` to `Odyssey:`.
-* `destination_platform`: The wiki's software. The current supported options are `mediawiki` and `doku`. If you are contributing a wiki that is on another wiki platform, please open an issue so that support for the platform can be added.
+* `destination_platform`: The wiki's software. The current supported options are `mediawiki` and `dokuwiki`. If you are contributing a wiki that is on another wiki platform, please open an issue so that support for the platform can be added.
 * `destination_icon`: The name of the wiki's favicon in the [favicons](favicons) folder.
 * `destination_main_page`: The title of the main page of the destination wiki.
 * `destination_search_path`: The URL path prefix for performing searches. On MediaWiki wikis, it is called the index.php entry point and can be found at Special:Version.

--- a/data/sitesDE.json
+++ b/data/sitesDE.json
@@ -12,10 +12,10 @@
     ],
     "destination": "Animal Crossing Wiki",
     "destination_base_url": "animalcrossingwiki.de",
-    "destination_platform": "doku",
+    "destination_platform": "dokuwiki",
     "destination_icon": "animalcrossingwiki.png",
     "destination_main_page": "start",
-    "destination_search_path": "/"
+    "destination_search_path": "/doku.php"
   },
   {
     "id": "de-detektivconan",

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -3718,10 +3718,10 @@
     ],
     "destination": "Severance Wiki",
     "destination_base_url": "severance.wiki",
-    "destination_platform": "doku",
+    "destination_platform": "dokuwiki",
     "destination_icon": "severancewiki.png",
     "destination_main_page": "Start",
-    "destination_search_path": "/"
+    "destination_search_path": "/doku.php"
   },
   {
     "id": "en-shroudoftheavatar",

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -100,7 +100,7 @@ function commonFunctionGetNewURL(originURL, matchingSite) {
     // Check if main page
     if (originArticle === matchingSite['origin_main_page']) {
       switch (matchingSite['destination_platform']) {
-        case 'doku':
+        case 'dokuwiki':
           destinationArticle = '';
           break;
         default:
@@ -125,8 +125,8 @@ function commonFunctionGetNewURL(originURL, matchingSite) {
       case 'mediawiki':
         searchParams = '?title=Special:Search&search=' + destinationArticle;
         break;
-      case 'doku':
-        searchParams = 'start?do=search&q=' + destinationArticle;
+      case 'dokuwiki':
+        searchParams = '?do=search&q=' + destinationArticle;
         break;
     }
     newURL = 'https://' + matchingSite["destination_base_url"] + matchingSite["destination_search_path"] + searchParams;


### PR DESCRIPTION
Renamed platform `doku` to `dokuwiki`. The software is named "DokuWiki", just like "MediaWiki".

The previous search path construction for DokuWiki wikis would fail for wikis that put their page names in query parameters instead of the path. For example, for the [Dicey Dungeons DokuWiki](https://wiki.diceydungeons.com/doku.php) (note that this wiki is not currently supported by IWB), https://wiki.diceydungeons.com/start?do=search is a 404 error. The solution is to use "doku.php" as the base URL, which always renders as the main page on DokuWikis regardless of their URL structure, so can safely be used as the base URL for searches.

However, to parallel MediaWiki wikis, which put "index.php" in the wiki-specific search_path, I've moved "doku.php" to the definitions of individual DokuWikis, so the JavaScript now only adds query parameters.