### PR TITLE
Repair Bulbapedia search path

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -3470,7 +3470,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "bulbapedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/w/index.php"
   },
   {
     "id": "en-portal",


### PR DESCRIPTION
Bulbapedia's search path was incorrectly listed as `/wiki/index.php` instead of `/w/index.php`. This caused redirection to Bulbapedia to fail, landing on the invalid wiki page https://bulbapedia.bulbagarden.net/wiki/index.php

I checked every other English site that listed `/wiki/index.php` as their search path, but all of the other cases appeared to be valid. I'm not sure how Bulbapedia alone ended up with an invalid search path.