### PR TITLE
Repair Wizard101 Wiki search path

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -5247,7 +5247,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wizard101wiki.png",
     "destination_main_page": "Wizard101_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/wiki/index.php"
   },
   {
     "id": "en-wizardry",


### PR DESCRIPTION
Wizard101 Wiki's search path was incorrect, causing redirection to fail.

(Wizard101 Wiki was added by one of my PRs, so this issue is definitely my fault.)