### PR TITLE
Repair Conan and Starfy Wiki paths

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1138,7 +1138,7 @@
       }
     ],
     "destination": "Detective Conan Wiki",
-    "destination_base_url": "www.detectiveconanworld.com/wiki",
+    "destination_base_url": "www.detectiveconanworld.com",
     "destination_platform": "mediawiki",
     "destination_icon": "detectiveconan.png",
     "destination_main_page": "Main_Page",
@@ -4251,7 +4251,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "starfy.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "https://www.starfywiki.org/index.php"
+    "destination_search_path": "/index.php"
   },
   {
     "id": "en-steamworld",
@@ -5088,7 +5088,7 @@
   },
   {
     "id": "en-warcraft",
-    "origins_label": "World of Warcraft Fandom & Neoseeker Wikis",
+    "origins_label": "Warcraft Fandom & Neoseeker Wikis",
     "origins": [
       {
         "origin": "Wowpedia Fandom Wiki",


### PR DESCRIPTION
Detective Conan Wiki included `/wiki` in both its base_url and search_path. While this doesn't actually cause search to fail (as the site seems to be able to resolve ?search= queries even when the base path is invalid), it does mean the URL path is invalid if attempting to use it for other purposes.

Starfy Wiki included its full URL in the search_path. This is consistent with how Starfy Wiki's MediaWiki API defines its search_path, but it violates assumptions made by IWB, causing generated redirects to fail.

Also, adjusted the origins_label for Warcraft Wiki.