### PR TITLE
Search filtering for Kagi

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Large, corporate-run wiki farms have enabled hundreds of great wikis and communi
 
 When visiting a wiki on a large corporate wiki farm such as Fandom, Indie Wiki Buddy will notify and/or automatically redirect you if a quality, independent alternative is available. You can customize your experience per-wiki.
 
-In addition, search results in Google, Bing, DuckDuckGo, Yahoo, Brave Search, Ecosia, Startpage, Qwant, and Yandex can also be filtered, replacing non-independent wikis with text inviting you to visit the independent counterpart.
+In addition, search results in Google, Bing, DuckDuckGo, Yahoo, Brave Search, Ecosia, Startpage, Qwant, Yandex, and Kagi can also be filtered, replacing non-independent wikis with text inviting you to visit the independent counterpart.
 
 Indie Wiki Buddy also supports [BreezeWiki](https://breezewiki.com/), a service that renders Fandom wikis without ads or bloat. This helps give you a more enjoyable reading experience on Fandom when an independent wiki isn't available.
 

--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -84,6 +84,7 @@
         "https://*.ya.ru/*",
         "https://*.startpage.com/*",
         "https://*.search.yahoo.com/*",
+        "https://kagi.com/search*",
         "https://www.google.com/search*",
         "https://www.google.ad/search*",
         "https://www.google.ae/search*",

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -162,6 +162,7 @@
         "https://*.ya.ru/*",
         "https://*.startpage.com/*",
         "https://*.search.yahoo.com/*",
+        "https://kagi.com/search*",
         "https://www.google.com/search*",
         "https://www.google.ad/search*",
         "https://www.google.ae/search*",

--- a/pages/guide/index.html
+++ b/pages/guide/index.html
@@ -101,7 +101,7 @@
         <br /><br />
         When you visit a wiki on a large, corporate-run wiki host, this extension can notify or automatically redirect
         you to quality independent wikis when they're available.
-        Search results in Google, Bing, DuckDuckGo, Yahoo, Brave Search, Ecosia, Startpage, Qwant, and Yandex can also be filtered,
+        Search results in Google, Bing, DuckDuckGo, Yahoo, Brave Search, Ecosia, Startpage, Qwant, Yandex, and Kagi can also be filtered,
         replacing non-independent wikis with links to independent counterpart (or hiding them completely).
         <br /><br />
         We currently redirect from Fandom and Fextralife wikis to independent counterparts.

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -335,6 +335,9 @@ function hideSearchResults(searchResultContainer, searchEngine, site, showBanner
           document.querySelector('#main-algo').prepend(searchRemovalNotice);
         }
         break;
+      case 'kagi':
+        document.querySelector('#main').prepend(searchRemovalNotice);
+        break;
       default:
     }
   }
@@ -484,6 +487,9 @@ async function filterSearchResults(searchResults, searchEngine, storage) {
                 break;
               case 'yahoo':
                 searchResultContainer = searchResult.closest('#web > ol > li div.itm .exp, #web > ol > li div.algo, #web > ol > li, section.algo');
+                break;
+              case 'kagi':
+                searchResultContainer = searchResult.closest('div.search-result, div.__srgi');
                 break;
               default:
             }
@@ -730,6 +736,23 @@ function main(mutations = null, observer = null) {
             document.addEventListener('readystatechange', e => {
               if (['interactive', 'complete'].includes(document.readyState)) {
                 filterYahoo();
+              }
+            }, { once: true });
+          }
+        } else if (currentURL.hostname.includes('kagi.com')) {
+          // Function to filter search results in Kagi
+          function filterKagi() {
+            let searchResults = document.querySelectorAll('h3>a[href*=".fandom.com"], h3>a[href*=".wiki.fextralife.com"], h3>a[href*=".neoseeker.com/wiki/"]');
+            filterSearchResults(searchResults, 'kagi', storage);
+          }
+
+          // Wait for document to be interactive/complete:
+          if (['interactive', 'complete'].includes(document.readyState)) {
+            filterKagi();
+          } else {
+            document.addEventListener('readystatechange', e => {
+              if (['interactive', 'complete'].includes(document.readyState)) {
+                filterKagi();
               }
             }, { once: true });
           }

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -742,7 +742,10 @@ function main(mutations = null, observer = null) {
         } else if (currentURL.hostname.includes('kagi.com')) {
           // Function to filter search results in Kagi
           function filterKagi() {
-            let searchResults = document.querySelectorAll('h3>a[href*=".fandom.com"], h3>a[href*=".wiki.fextralife.com"], h3>a[href*=".neoseeker.com/wiki/"]');
+            let searchResults = Array.from(document.querySelectorAll('h3>a, a.__sri-url')).filter(el =>
+              el.href?.includes('.fandom.com') ||
+              el.href?.includes('.wiki.fextralife.com') ||
+              el.href?.includes('.neoseeker.com/wiki/'));
             filterSearchResults(searchResults, 'kagi', storage);
           }
 


### PR DESCRIPTION
Adds search filtering for [Kagi](https://kagi.com/)

![image](https://github.com/KevinPayravi/indie-wiki-buddy/assets/56560271/d13d5ea5-5b1e-49f7-9823-79141259d135)

![image](https://github.com/KevinPayravi/indie-wiki-buddy/assets/56560271/6d3205c2-87e0-49b7-bc88-d2a71e37c15c)

![image](https://github.com/KevinPayravi/indie-wiki-buddy/assets/56560271/7ee15fc8-9ace-40ba-bd5d-01a0afc61d5d)
