### PR TITLE
Add Smash Bros Neoseeker wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -4786,13 +4786,19 @@
   },
   {
     "id": "en-supersmashbros",
-    "origins_label": "Super Smash Bros. Fandom Wiki",
+    "origins_label": "Super Smash Bros. Fandom & Neoseeeker Wikis",
     "origins": [
       {
         "origin": "Super Smash Bros. Fandom Wiki",
         "origin_base_url": "supersmashbros.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Smashpedia"
+      },
+      {
+        "origin": "Smash Bros Wiki - Neoseeker",
+        "origin_base_url": "smashbros.neoseeker.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Main_Page"
       }
     ],
     "destination": "SmashWiki",


### PR DESCRIPTION
Noticed that Indie Wiki Buddy started adding Neoseeker wikis. I couldn't find duplicate issues/PRs (seems to have been missed by #461), so I have added the [Smash Bros Neoseeker wiki](https://smashbros.neoseeker.com/wiki/Main_Page) to [SmashWiki](https://www.ssbwiki.com).