### PR TITLE
Update Severance Wiki origin URL

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -4407,7 +4407,7 @@
     "origins": [
       {
         "origin": "Severance Fandom Wiki",
-        "origin_base_url": "severance-series.fandom.com",
+        "origin_base_url": "severance-tv.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Severance_Wiki"
       }


### PR DESCRIPTION
The Severance Fandom Wiki has updated the subdomain to severance-tv instead of severance-series. The old Fandom URLs automatically redirect to the new subdomain, and Google appears to have caught on in its search results so I replaced the origin instead of adding a new one.