### PR TITLE
Adding destination content paths + data refresh

### DIFF
--- a/data/sitesDE.json
+++ b/data/sitesDE.json
@@ -15,7 +15,8 @@
     "destination_platform": "dokuwiki",
     "destination_icon": "animalcrossingwiki.png",
     "destination_main_page": "start",
-    "destination_search_path": "/doku.php"
+    "destination_search_path": "/doku.php",
+    "destination_content_path": "/"
   },
   {
     "id": "de-ark",
@@ -56,7 +57,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "detektivconan.png",
     "destination_main_page": "Hauptseite",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "de-minecraft",
@@ -93,7 +95,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "pokewiki.png",
     "destination_main_page": "Hauptseite",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "de-starcitizen",
@@ -111,7 +114,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "starcitizen.png",
     "destination_main_page": "Star_Citizen_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "de-terraria",
@@ -152,6 +156,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikiraiderde.png",
     "destination_main_page": "Hauptseite",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   }
 ]

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -3640,7 +3640,7 @@
       },
       {
         "origin": "Pokémon Mystery Dungeon Fandom Wiki",
-        "origin_base_url": "pokemon.fandom.com",
+        "origin_base_url": "pmd-rt-archive.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Pokémon_Wiki"
       }

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -15,7 +15,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "2xkowiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/mw/index.php"
+    "destination_search_path": "/mw/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-acecombat",
@@ -61,7 +62,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "warswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-adventurezone",
@@ -80,6 +82,7 @@
     "destination_icon": "adventurezonewiki.png",
     "destination_main_page": "The_Adventure_Zone_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -101,6 +104,7 @@
     "destination_icon": "akudamadrivewiki.png",
     "destination_main_page": "Akudama_Drive_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -145,7 +149,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "nookipedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-animalcrossingpocketcamp",
@@ -185,7 +190,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "anothereden.png",
     "destination_main_page": "Another_Eden_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-answeredprayers",
@@ -204,7 +210,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "answeredprayerswiki.png",
     "destination_main_page": "Answered_Prayers_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-anvilempires",
@@ -274,6 +281,7 @@
     "destination_icon": "apicowiki.png",
     "destination_main_page": "Welcome_to_the_APICO_Wiki!",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze",
       "official"
@@ -340,7 +348,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "arms.png",
     "destination_main_page": "Home",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-ashesofcreation",
@@ -364,7 +373,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "ashesofcreationwiki.png",
     "destination_main_page": "Ashes_of_Creation_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-ashestown",
@@ -383,6 +393,7 @@
     "destination_icon": "ashestownwiki.png",
     "destination_main_page": "Ashes.town_Wiki",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "wiki.gg"
     ]
@@ -409,7 +420,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "assaultlilywiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-astroneer",
@@ -478,7 +490,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "azurlanewiki.png",
     "destination_main_page": "Azur_Lane_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-backpackbattles",
@@ -519,6 +532,7 @@
     "destination_icon": "backpackherowiki.png",
     "destination_main_page": "Backpack_Hero_Wiki",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "wiki.gg"
     ]
@@ -539,7 +553,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "bakugan.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-baldursgate3",
@@ -557,7 +572,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "baldursgate3.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-banjokazooie",
@@ -581,7 +597,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "jiggywikki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-barotrauma",
@@ -599,7 +616,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "barotrauma.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/baro-wiki/index.php"
+    "destination_search_path": "/baro-wiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-battlebit",
@@ -640,7 +658,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "battlestarwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-bellasara",
@@ -680,7 +699,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "biosector01.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-blazblue",
@@ -698,7 +718,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "blazblue.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-bluearchive",
@@ -716,7 +737,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "bluearchive.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-boardgameonline",
@@ -735,6 +760,7 @@
     "destination_icon": "boardgameonlinewiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -779,7 +805,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "braingirlwiki.png",
     "destination_main_page": "Braingirl_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-brandonsanderson",
@@ -803,7 +830,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "coppermind.png",
     "destination_main_page": "Coppermind:Welcome",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-brawlhalla",
@@ -822,6 +850,7 @@
     "destination_icon": "brawlhallawiki.png",
     "destination_main_page": "Brawlhalla_Wiki",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "wiki.gg"
     ]
@@ -842,7 +871,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "brotatowiki.png",
     "destination_main_page": "Brotato_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-bz",
@@ -856,11 +886,12 @@
       }
     ],
     "destination": "B'z Wiki",
-    "destination_base_url": "bzwiki.com",
+    "destination_base_url": "www.bzwiki.com",
     "destination_platform": "mediawiki",
     "destination_icon": "bzwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-calamitymod",
@@ -888,12 +919,12 @@
   {
     "id": "en-carrion",
     "origins_label": "Carrion Fandom Wiki",
-    "origins":[
+    "origins": [
       {
-      "origin": "Carrion Fandom Wiki",
-      "origin_base_url": "carrion.fandom.com",
-      "origin_content_path": "/wiki/",
-      "origin_main_page": "Carrion_Wiki"
+        "origin": "Carrion Fandom Wiki",
+        "origin_base_url": "carrion.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Carrion_Wiki"
       }
     ],
     "destination": "Carrion Wiki",
@@ -923,7 +954,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "celeste.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-cerasus",
@@ -942,7 +977,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "cerasuswiki.png",
     "destination_main_page": "Cerasus_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-chicory",
@@ -961,6 +997,7 @@
     "destination_icon": "chicory.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -981,7 +1018,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "chipschallenge.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-chrono",
@@ -1005,7 +1043,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "chrono.png",
     "destination_main_page": "Chrono_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-cityofheroes",
@@ -1023,7 +1062,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "paragonwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-commanderkeen",
@@ -1041,7 +1081,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "commanderkeenwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-commodore64",
@@ -1059,7 +1100,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "c64.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-conwaysgameoflife",
@@ -1077,7 +1119,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "lifewiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-cookieclicker",
@@ -1118,6 +1161,7 @@
     "destination_icon": "cookiepedia.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -1161,7 +1205,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "creatureswiki.png",
     "destination_main_page": "Creatures_Wiki_Homepage",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-criticalrole",
@@ -1180,6 +1225,7 @@
     "destination_icon": "criticalrole.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -1200,7 +1246,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "daria.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-darkanddarker",
@@ -1218,7 +1268,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "darkanddarkerwiki.png",
     "destination_main_page": "Dark_and_Darker_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-darkestdungeon",
@@ -1311,7 +1362,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "destinypedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-detectiveconan",
@@ -1325,11 +1377,12 @@
       }
     ],
     "destination": "Detective Conan Wiki",
-    "destination_base_url": "www.detectiveconanworld.com/wiki",
+    "destination_base_url": "www.detectiveconanworld.com",
     "destination_platform": "mediawiki",
     "destination_icon": "detectiveconan.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-digimon",
@@ -1353,7 +1406,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikimon.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-doctorwho",
@@ -1377,7 +1431,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "tardiswiki.png",
     "destination_main_page": "Doctor_Who_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-dogcraft",
@@ -1395,7 +1450,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dogcraftwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-dontstarve",
@@ -1442,7 +1498,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "doomwiki.png",
     "destination_main_page": "Entryway",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-dotflow",
@@ -1461,7 +1518,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dotflowwiki.png",
     "destination_main_page": "Dotflow_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-dragalialost",
@@ -1479,7 +1537,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dragalialost.png",
     "destination_main_page": "Dragalia_Lost_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-drawntolife",
@@ -1497,7 +1556,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wapopedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/en/"
   },
   {
     "id": "en-dreamlightvalley",
@@ -1521,7 +1581,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dreamlightvalleywiki.png",
     "destination_main_page": "Dreamlight_Valley_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-dredge",
@@ -1561,7 +1622,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dungeonsanddragonswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-dwarffortress",
@@ -1579,7 +1641,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dwarffortresswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-dyinglight",
@@ -1625,7 +1688,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikibound.png",
     "destination_main_page": "WikiBound",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-eiyudenchronicle",
@@ -1700,7 +1764,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "uesp.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-ena",
@@ -1741,6 +1806,7 @@
     "destination_icon": "enterthegungeonwiki.png",
     "destination_main_page": "Enter_the_Gungeon_Wiki",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "wiki.gg",
       "official"
@@ -1763,6 +1829,7 @@
     "destination_icon": "erepublikwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/",
     "tags": "official"
   },
   {
@@ -1782,6 +1849,7 @@
     "destination_icon": "essentialsenginewiki.png",
     "destination_main_page": "Essentials_Engine_wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -1808,7 +1876,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "evawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-factorio",
@@ -1827,6 +1896,7 @@
     "destination_icon": "factorio.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -1859,7 +1929,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "fallout.png",
     "destination_main_page": "Fallout_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-famicom",
@@ -1877,7 +1948,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "famiwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-farmingsimulator",
@@ -1917,7 +1989,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "zerowiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-fearandhunger",
@@ -1958,6 +2031,7 @@
     "destination_icon": "findeverythingwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -1984,7 +2058,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "fireemblem.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-frackinuniverse",
@@ -2003,6 +2078,7 @@
     "destination_icon": "frackinuniversewiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze",
       "official"
@@ -2024,7 +2100,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "freespacewiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-fridaynightfunkin",
@@ -2100,7 +2177,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "friendsatthetable.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/view/"
   },
   {
     "id": "en-fromargonavis",
@@ -2119,6 +2197,7 @@
     "destination_icon": "fromargonaviswiki.png",
     "destination_main_page": "from_ARGONAVIS_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2145,7 +2224,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "infosphere.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-fzero",
@@ -2169,7 +2249,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "fzero.png",
     "destination_main_page": "F-Zero_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-galaxylife",
@@ -2215,7 +2296,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "awikioficeandfire.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-genfanad",
@@ -2233,7 +2315,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "genfanadwiki.png",
     "destination_main_page": "Genfanad_Wiki",
-    "destination_search_path": "/"
+    "destination_search_path": "/",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-gex",
@@ -2252,6 +2335,7 @@
     "destination_icon": "gexpedia.png",
     "destination_main_page": "Gexpedia",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2278,7 +2362,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "giganticwiki.png",
     "destination_main_page": "Gigantic_Wiki:Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-girlsfrontline",
@@ -2296,7 +2384,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "iopwiki.png",
     "destination_main_page": "IOP_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-girlslasttour",
@@ -2315,6 +2404,7 @@
     "destination_icon": "girlslasttourwiki.png",
     "destination_main_page": "Girls'_Last_Tour_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2335,7 +2425,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikizilla.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-goldensun",
@@ -2359,7 +2450,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "goldensun.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-graalmilitary",
@@ -2378,6 +2470,7 @@
     "destination_icon": "graalmilitarywiki.png",
     "destination_main_page": "GraalMilitary_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2398,7 +2491,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "granblue.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-greenday",
@@ -2417,6 +2511,7 @@
     "destination_icon": "greendaywiki.png",
     "destination_main_page": "Green_Day_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "shoutwiki"
     ]
@@ -2438,11 +2533,12 @@
     "destination_icon": "guildwarswiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]
   },
-    {
+  {
     "id": "en-guiltygear",
     "origins_label": "Guilty Gear Fandom Wiki",
     "origins": [
@@ -2480,7 +2576,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "habboxwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-halflife",
@@ -2504,7 +2601,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "combine.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-halo",
@@ -2528,7 +2626,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "halopedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-hannabarbera",
@@ -2546,7 +2645,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "hannabarberawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-hearthstone",
@@ -2592,7 +2692,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "heroeswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-hollowknight",
@@ -2616,7 +2717,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "hollowknight.png",
     "destination_main_page": "Hollow_Knight_Wiki",
-    "destination_search_path": "/mw/index.php"
+    "destination_search_path": "/mw/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-holocure",
@@ -2656,7 +2758,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "hololive.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-homm3",
@@ -2674,7 +2780,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "heroes3wiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-honeyworkspremiumlive",
@@ -2693,6 +2800,7 @@
     "destination_icon": "honeyworkspremiumlivewiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2714,6 +2822,7 @@
     "destination_icon": "houkaigakuen2wiki.png",
     "destination_main_page": "Houkai_Gakuen_2_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2735,6 +2844,7 @@
     "destination_icon": "hyperrogue.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official",
       "miraheze"
@@ -2757,6 +2867,7 @@
     "destination_icon": "idolish7.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2777,7 +2888,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "projectimas.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-instarsandtime",
@@ -2818,6 +2930,7 @@
     "destination_icon": "interpalorewiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -2838,7 +2951,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "jojo.png",
     "destination_main_page": "JoJo_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-kancolle",
@@ -2856,7 +2970,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "kancollewiki.png",
     "destination_main_page": "Kancolle_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-kemonofriends",
@@ -2874,7 +2989,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "japarilibrary.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-kentuckyroutezero",
@@ -2892,7 +3008,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "highway0.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/~donald/zero/index.php"
+    "destination_search_path": "/~donald/zero/index.php",
+    "destination_content_path": "/~donald/zero/"
   },
   {
     "id": "en-kerbalspaceprogram",
@@ -2911,6 +3028,7 @@
     "destination_icon": "kerbalspaceprogramwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]
@@ -2937,7 +3055,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "khwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-kirby",
@@ -2961,7 +3080,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikirby.png",
     "destination_main_page": "Kirby_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-knucklecracker",
@@ -2975,11 +3095,12 @@
       }
     ],
     "destination": "Knuckle Cracker Wiki",
-    "destination_base_url": "knucklecracker.com/wiki",
+    "destination_base_url": "knucklecracker.com",
     "destination_platform": "dokuwiki",
     "destination_icon": "knucklecrackerwiki.png",
     "destination_main_page": "start",
-    "destination_search_path": "/doku.php"
+    "destination_search_path": "/wiki/doku.php",
+    "destination_content_path": "/wiki/doku.php?id="
   },
   {
     "id": "en-koeitecmo",
@@ -2997,7 +3118,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "koeitecmowiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-lastorigin",
@@ -3059,7 +3181,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "gineipaedia.png",
     "destination_main_page": "Portal:Main",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-lethalcompany",
@@ -3078,6 +3201,7 @@
     "destination_icon": "lethalcompany.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -3104,7 +3228,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "tolkiengateway.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-mabinogi",
@@ -3122,7 +3247,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "mabinogiworldwiki.png",
     "destination_main_page": "Wiki_Home",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/view/"
   },
   {
     "id": "en-madokamagica",
@@ -3140,7 +3266,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "puellamagi.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-magicalmixturemill",
@@ -3181,7 +3308,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikiofmana.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-mario",
@@ -3211,7 +3339,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "supermariowiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-mcci",
@@ -3229,7 +3358,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "mcciwiki.png",
     "destination_main_page": "Home",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-megamitensei",
@@ -3253,7 +3383,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "megamitenseiwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-melvoridle",
@@ -3271,7 +3402,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "melvoridlewiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-micronations",
@@ -3289,7 +3421,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "microwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-mii",
@@ -3307,7 +3440,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "miiwiki.png",
     "destination_main_page": "Mii_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-mindhack",
@@ -3397,6 +3531,7 @@
     "destination_icon": "minetestwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -3469,6 +3604,7 @@
     "destination_icon": "equestripedia.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -3489,7 +3625,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "guildofarchivists.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-mysterydungeon",
@@ -3503,7 +3640,7 @@
       },
       {
         "origin": "Pokémon Mystery Dungeon Fandom Wiki",
-        "origin_base_url": "pmd-rt-archive.fandom.com",
+        "origin_base_url": "pokemon.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Pokémon_Wiki"
       }
@@ -3513,7 +3650,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "mysterydungeon.png",
     "destination_main_page": "Mystery_Dungeon_Franchise_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-necrodancer",
@@ -3532,6 +3670,7 @@
     "destination_icon": "cryptofthenecrodancerwiki.png",
     "destination_main_page": "NecroDancer_Wiki:About",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -3574,7 +3713,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "nethack.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-noita",
@@ -3614,7 +3754,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "obeymewiki.png",
     "destination_main_page": "Main",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-oldschoolrunescape",
@@ -3677,7 +3818,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "osamusato.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-palia",
@@ -3740,7 +3882,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "pathfinder.png",
     "destination_main_page": "Pathfinder_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-pathofexile",
@@ -3758,7 +3901,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "pathofexile.png",
     "destination_main_page": "Path_of_Exile_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-pathologic",
@@ -3817,11 +3961,12 @@
       }
     ],
     "destination": "PHIGHTING! Wiki",
-    "destination_base_url": "phighting.miraheze.org",
+    "destination_base_url": "phighting.wiki",
     "destination_platform": "mediawiki",
     "destination_icon": "phightingwiki.png",
     "destination_main_page": "PHIGHTING!_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze",
       "official"
@@ -3849,7 +3994,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "pikipedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-pizzatower",
@@ -3868,6 +4014,7 @@
     "destination_icon": "pizzatowerwiki.png",
     "destination_main_page": "Pizza_Tower_Wiki:Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -3922,7 +4069,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "bulbapedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-portal",
@@ -3940,7 +4088,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "portalwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-prisonarchitect",
@@ -3959,6 +4108,7 @@
     "destination_icon": "prisonarchitectwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -3979,7 +4129,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "sekaipedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-projectwingman",
@@ -4020,6 +4174,7 @@
     "destination_icon": "pzwiki.png",
     "destination_main_page": "Special:MyLanguage/Project_Zomboid_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]
@@ -4040,7 +4195,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "protochromawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/view/"
   },
   {
     "id": "en-pubg",
@@ -4081,7 +4237,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "puyonexus.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/mediawiki/index.php"
+    "destination_search_path": "/mediawiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-rainworld",
@@ -4106,6 +4263,7 @@
     "destination_icon": "rainworld.png",
     "destination_main_page": "Rain_World_Wiki",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official",
       "miraheze"
@@ -4127,7 +4285,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "rayman.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/script-en/index.php"
+    "destination_search_path": "/wiki/script-en/index.php",
+    "destination_content_path": "/wiki/en/"
   },
   {
     "id": "en-rct",
@@ -4145,7 +4304,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "rctwiki.png",
     "destination_main_page": "RollerCoaster_Tycoon_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-rhythmdoctor",
@@ -4163,7 +4326,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "rhythmdoctorwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/page/"
   },
   {
     "id": "en-rhythmheaven",
@@ -4180,8 +4344,9 @@
     "destination_base_url": "rhwiki.net",
     "destination_platform": "mediawiki",
     "destination_icon": "rhythmheavenwiki.png",
-    "destination_main_page": "Home",
-    "destination_search_path": "/w/index.php"
+    "destination_main_page": "Main_Page",
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-riichimahjong",
@@ -4199,7 +4364,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "japanesemahjongwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-rimworld",
@@ -4217,7 +4383,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "rimworldwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-riskofrain",
@@ -4279,7 +4446,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "coasterpedia.png",
     "destination_main_page": "Coasterpedia_The_Roller_Coaster_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-runescape",
@@ -4326,6 +4494,7 @@
     "destination_icon": "runescapeclassic.png",
     "destination_main_page": "RuneScape_Classic_Wiki",
     "destination_search_path": "/",
+    "destination_content_path": "/w/",
     "tags": [
       "official"
     ]
@@ -4346,7 +4515,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "sagawiki.png",
     "destination_main_page": "SaGa_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-sailormoon",
@@ -4364,7 +4534,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikimoon.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-salemmmo",
@@ -4382,7 +4553,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "salemwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/page/"
   },
   {
     "id": "en-sanrio",
@@ -4400,7 +4572,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "sanriowiki.png",
     "destination_main_page": "Sanrio_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-satisfactory",
@@ -4442,6 +4615,7 @@
     "destination_icon": "ovalkwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php?title=",
     "tags": [
       "official"
     ]
@@ -4484,7 +4658,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "segaretro.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-sel",
@@ -4502,7 +4677,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "serialexperimentslainwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-severanceseries",
@@ -4520,7 +4696,8 @@
     "destination_platform": "dokuwiki",
     "destination_icon": "severancewiki.png",
     "destination_main_page": "Start",
-    "destination_search_path": "/doku.php"
+    "destination_search_path": "/doku.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-shroudoftheavatar",
@@ -4538,7 +4715,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "sotawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/sota/"
   },
   {
     "id": "en-signalis",
@@ -4584,7 +4762,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikisimpsons.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-songsofsyx",
@@ -4603,6 +4782,7 @@
     "destination_icon": "songsofsyxwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/",
     "tags": [
       "official"
     ]
@@ -4645,7 +4825,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "spacestation13wiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-spiritmod",
@@ -4685,7 +4866,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "inkipedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-starbound",
@@ -4704,6 +4886,7 @@
     "destination_icon": "starbounder.png",
     "destination_main_page": "Starbound_Wiki",
     "destination_search_path": "/mediawiki/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -4724,7 +4907,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "starcitizen.png",
     "destination_main_page": "Star_Citizen_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-stardewvalley",
@@ -4743,6 +4927,7 @@
     "destination_icon": "stardew.png",
     "destination_main_page": "Stardew_Valley_Wiki",
     "destination_search_path": "/mediawiki/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -4770,7 +4955,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "starfieldwiki.png",
     "destination_main_page": "Home",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-starfy",
@@ -4788,7 +4974,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "starfy.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "https://www.starfywiki.org/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-steamworld",
@@ -4828,7 +5015,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "sto.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-sugaryspire",
@@ -4869,7 +5057,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "gensopedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-sunhaven",
@@ -4937,7 +5126,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "smashwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-tallyhall",
@@ -4954,8 +5144,9 @@
     "destination_base_url": "www.hiddeninthesand.com",
     "destination_platform": "mediawiki",
     "destination_icon": "tallyhallmanac.png",
-    "destination_main_page": "Tally_Hallmanac",
-    "destination_search_path": "/wiki/index.php"
+    "destination_main_page": "Main_Page",
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-tcoaal",
@@ -4965,7 +5156,7 @@
         "origin": "The Coffin of Andy and Leyley Fandom Wiki",
         "origin_base_url": "coffin-of-andy-and-leyley.fandom.com",
         "origin_content_path": "/wiki/",
-        "origin_main_page": "The_Coffin_of_Andy_%26_LeyLey_Wiki"
+        "origin_main_page": "The_Coffin_of_Andy_&_LeyLey_Wiki"
       }
     ],
     "destination": "The Coffin of Andy and Leyley Wiki",
@@ -4973,7 +5164,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "tcoaal.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-teamfortress",
@@ -4992,6 +5184,7 @@
     "destination_icon": "teamfortress.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]
@@ -5012,7 +5205,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "tearsofthemis.png",
     "destination_main_page": "Tears_of_Themis_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-temtem",
@@ -5111,7 +5305,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "terrypratchettwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-thecyclefrontier",
@@ -5129,7 +5324,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "tcfwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-thefinals",
@@ -5147,7 +5343,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "thefinalswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w139/index.php"
+    "destination_search_path": "/w139/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-thewanderinginn",
@@ -5166,6 +5363,7 @@
     "destination_icon": "thewanderinginnwiki.png",
     "destination_main_page": "The_Wandering_Inn_Wiki",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -5186,7 +5384,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "thismightbeawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-thoriummod",
@@ -5250,7 +5449,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "tinyrogueswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-tombraider",
@@ -5268,7 +5468,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikiraider.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-toontowncorporateclash",
@@ -5309,6 +5510,7 @@
     "destination_icon": "toontownrewrittenwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -5330,6 +5532,7 @@
     "destination_icon": "tornwiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]
@@ -5350,7 +5553,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "touhouwiki.png",
     "destination_main_page": "Touhou_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-towerclimb",
@@ -5391,6 +5595,7 @@
     "destination_icon": "towerfallwiki.png",
     "destination_main_page": "TowerFall_Wiki",
     "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "wiki.gg"
     ]
@@ -5433,7 +5638,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "transformers.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-travellerrpg",
@@ -5451,7 +5657,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "travellerwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-trucksimulator",
@@ -5487,9 +5694,9 @@
       },
       {
         "origin": "Two Worlds II Fandom Wiki",
-        "origin_base_url": "tw2.fandom.com",
+        "origin_base_url": "community.fandom.com",
         "origin_content_path": "/wiki/",
-        "origin_main_page": "Two_Worlds_2_Wiki"
+        "origin_main_page": "Community_Central"
       }
     ],
     "destination": "Two Worlds Wiki",
@@ -5497,7 +5704,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "twoworldswiki.png",
     "destination_main_page": "Two_Worlds_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-ubfunkeys",
@@ -5515,7 +5723,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "ubfunkeyswiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php?title="
   },
   {
     "id": "en-ultrakill",
@@ -5534,6 +5743,7 @@
     "destination_icon": "ultrawiki.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "miraheze"
     ]
@@ -5578,7 +5788,11 @@
     "destination_icon": "undertaleyellowwiki.png",
     "destination_main_page": "Undertale_Yellow_Wiki",
     "destination_search_path": "/index.php",
-    "destination_content_path": "/wiki/"},
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "wiki.gg"
+    ]
+  },
   {
     "id": "en-unevendream",
     "origins_label": "Uneven Dream Fandom Wiki",
@@ -5596,7 +5810,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "unevendreamwiki.png",
     "destination_main_page": "Uneven_Dream_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-unrealworld",
@@ -5614,7 +5829,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "unrealworldwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/wiki/index.php",
+    "destination_content_path": "/wiki/index.php?title="
   },
   {
     "id": "en-vaporwave",
@@ -5632,7 +5848,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "vaporwavewiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-vendettaonline",
@@ -5650,7 +5867,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "vendettawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-voidrainsuponherheart",
@@ -5718,7 +5936,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "viki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-warcraft",
@@ -5782,7 +6001,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "lexicanum.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/mediawiki/index.php"
+    "destination_search_path": "/mediawiki/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-weezer",
@@ -5800,7 +6020,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "weezerpedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-wildfrost",
@@ -5819,7 +6040,7 @@
     "destination_icon": "wildfrostwiki.png",
     "destination_main_page": "Wildfrost_Wiki",
     "destination_search_path": "/index.php",
-    "destination_content_path": "/wiki/",
+    "destination_content_path": "/",
     "tags": [
       "official"
     ]
@@ -5881,11 +6102,12 @@
       }
     ],
     "destination": "Wizard101 Wiki",
-    "destination_base_url": "wiki.wizard101central.com",
+    "destination_base_url": "wiki.wizard101central.com/wiki",
     "destination_platform": "mediawiki",
     "destination_icon": "wizard101wiki.png",
     "destination_main_page": "Wizard101_Wiki",
-    "destination_search_path": "/wiki/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-wizardry",
@@ -5925,7 +6147,11 @@
     "destination_platform": "mediawiki",
     "destination_icon": "worldtrigger.png",
     "destination_main_page": "Welcome_to_the_World_Trigger_Wiki",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "tags": [
+      "miraheze"
+    ]
   },
   {
     "id": "en-wvyern",
@@ -5943,7 +6169,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wyvernsource.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/index.php/"
   },
   {
     "id": "en-xenharmonic",
@@ -5961,7 +6188,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "xenharmonicwiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/w/"
   },
   {
     "id": "en-yugioh",
@@ -6021,7 +6249,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "yugipedia.png",
     "destination_main_page": "Yugipedia",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-yume2kki",
@@ -6040,7 +6269,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "yume2kkiwiki.png",
     "destination_main_page": "Yume_2kki_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-yumenikki",
@@ -6059,7 +6289,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "yumenikkiwiki.png",
     "destination_main_page": "Yume_Nikki_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-yumenikkifangames",
@@ -6077,7 +6308,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "yumenikkifanwiki.png",
     "destination_main_page": "Yume_Nikki_Fangames_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "en-zelda",
@@ -6107,6 +6339,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "zeldapedia.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   }
 ]

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -5694,9 +5694,9 @@
       },
       {
         "origin": "Two Worlds II Fandom Wiki",
-        "origin_base_url": "community.fandom.com",
+        "origin_base_url": "tw2.fandom.com",
         "origin_content_path": "/wiki/",
-        "origin_main_page": "Community_Central"
+        "origin_main_page": "Two_Worlds_2_Wiki"
       }
     ],
     "destination": "Two Worlds Wiki",

--- a/data/sitesES.json
+++ b/data/sitesES.json
@@ -15,7 +15,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "amiibopedia.png",
     "destination_main_page": "Amiibopedia",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "es-animalcrossing",
@@ -33,7 +34,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "animalcrossing.png",
     "destination_main_page": "Portada",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "es-ark",
@@ -161,7 +163,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikidex.png",
     "destination_main_page": "WikiDex",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "es-splatoon",
@@ -179,7 +182,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "inkipedia.png",
     "destination_main_page": "Página_principal",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "es-supersmashbros",
@@ -197,7 +201,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "smashpedia.png",
     "destination_main_page": "SmashPedia",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "es-teamfortress",
@@ -217,6 +222,7 @@
     "destination_icon": "teamfortress.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]
@@ -260,6 +266,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "touhouwiki.png",
     "destination_main_page": "Touhou_Wiki",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   }
 ]

--- a/data/sitesFI.json
+++ b/data/sitesFI.json
@@ -16,6 +16,7 @@
     "destination_icon": "jedipedia.png",
     "destination_main_page": "Etusivu",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "shoutwiki"
     ]
@@ -37,6 +38,7 @@
     "destination_icon": "junawiki.png",
     "destination_main_page": "Etusivu",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "shoutwiki"
     ]

--- a/data/sitesFR.json
+++ b/data/sitesFR.json
@@ -38,7 +38,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "dragonquest.png",
     "destination_main_page": "Wiki_Dragon_Quest",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "fr-fallout",
@@ -56,7 +57,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "lesarchivesdevaulttec.png",
     "destination_main_page": "Accueil",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "fr-heroes",
@@ -117,7 +119,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "pokepedia.png",
     "destination_main_page": "Portail:Accueil",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "fr-terraria",

--- a/data/sitesIT.json
+++ b/data/sitesIT.json
@@ -38,7 +38,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikibound.png",
     "destination_main_page": "Pagina_principale",
-    "destination_search_path": "/w/index.php"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   },
   {
     "id": "it-mario",
@@ -56,7 +57,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "supermariowiki.png",
     "destination_main_page": "Pagina_principale",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   },
   {
     "id": "it-pokemon",
@@ -74,6 +76,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "pokemoncentral.png",
     "destination_main_page": "Home",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/"
   }
 ]

--- a/data/sitesPL.json
+++ b/data/sitesPL.json
@@ -38,7 +38,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "rayman.png",
     "destination_main_page": "Strona_główna",
-    "destination_search_path": "/wiki/script-pl/index.php"
+    "destination_search_path": "/wiki/script-pl/index.php",
+    "destination_content_path": "/wiki/pl/"
   },
   {
     "id": "pl-teamfortress",
@@ -58,6 +59,7 @@
     "destination_icon": "teamfortress.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]

--- a/data/sitesPT.json
+++ b/data/sitesPT.json
@@ -100,6 +100,7 @@
     "destination_icon": "teamfortress.png",
     "destination_main_page": "Main_Page",
     "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
     "tags": [
       "official"
     ]

--- a/data/sitesTOK.json
+++ b/data/sitesTOK.json
@@ -15,6 +15,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikipesija.png",
     "destination_main_page": "lipu_open",
-    "destination_search_path": "/index.php"
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
   }
 ]


### PR DESCRIPTION
The new Google search reordering feature (https://github.com/KevinPayravi/indie-wiki-buddy/pull/583) requires destination content paths to be re-added to our site data. PR 583 included adding destination content paths to wiki.gg + a select few wikis. This PR adds the destination content paths for the rest, made possible by a new refresh script made by @SnorlaxMonster. The refresh script also updated a few other properties + added missing tags.

Marking as draft; need to run through and make sure all the additions/changes look good.