### PR TITLE
Added Several Fextra Redirects

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -3702,7 +3702,7 @@
   },
   {
     "id": "en-minecraft",
-    "origins_label": "Minecraft Fandom & Neoseeker Wikis",
+    "origins_label": "Minecraft Fandom, Neoseeker, & Fextra Wikis",
     "origins": [
       {
         "origin": "Minecraft Fandom Wiki",

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1375,7 +1375,7 @@
         "origin_base_url": "darkestdungeon2.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Darkest+Dungeon+2+Wiki"
-      },
+      }
     ],
     "destination": "Darkest Dungeon Wiki",
     "destination_base_url": "darkestdungeon.wiki.gg",
@@ -1456,13 +1456,13 @@
         "origin_base_url": "destiny.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Destiny+Wiki"
-      },
+      }
       {
         "origin": "Destiny 2 Wiki - Fextralife",
         "origin_base_url": "destiny2.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Destiny+2+Wiki"
-      },
+      }
     ],
     "destination": "Destinypedia",
     "destination_base_url": "www.destinypedia.com",
@@ -2092,7 +2092,7 @@
         "origin_base_url": "fallout76.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Fallout+76+Wiki"
-      },
+      }
     ],
     "destination": "Independent Fallout Wiki",
     "destination_base_url": "fallout.wiki",
@@ -2908,7 +2908,7 @@
         "origin_base_url": "hollowknightsilksong.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Hollow+Knight+Silksong+Wiki"
-      },
+      }
     ],
     "destination": "Hollow Knight Wiki",
     "destination_base_url": "hollowknight.wiki",
@@ -3751,7 +3751,7 @@
         "origin_base_url": "minecraftdungeons.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Minecraft+Dungeons+Wiki"
-      },
+      }
     ],
     "destination": "Minecraft Wiki",
     "destination_base_url": "minecraft.wiki",
@@ -6791,7 +6791,7 @@
         "origin_base_url": "zeldatearsofthekingdom.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Zelda+Tears+of+the+Kingdom+Wiki"
-      },
+      }
     ],
     "destination": "Zelda Wiki",
     "destination_base_url": "zeldawiki.wiki",

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1369,13 +1369,13 @@
         "origin_base_url": "darkestdungeon.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Darkest_Dungeon_Wiki"
-      }
+      },
       {
         "origin": "Darkest Dungeon 2 Wiki - Fextralife",
         "origin_base_url": "darkestdungeon2.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Darkest+Dungeon+2+Wiki"
-      }
+      },
     ],
     "destination": "Darkest Dungeon Wiki",
     "destination_base_url": "darkestdungeon.wiki.gg",
@@ -1450,19 +1450,19 @@
         "origin_base_url": "destiny.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
-      }
+      },
       {
         "origin": "Destiny Wiki - Fextralife",
         "origin_base_url": "destiny.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Destiny+Wiki"
-      }
+      },
       {
         "origin": "Destiny 2 Wiki - Fextralife",
         "origin_base_url": "destiny2.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Destiny+2+Wiki"
-      }
+      },
     ],
     "destination": "Destinypedia",
     "destination_base_url": "www.destinypedia.com",
@@ -2080,19 +2080,19 @@
         "origin_base_url": "fallout.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
-      }
+      },
       {
         "origin": "Fallout 4 Wiki - Fextralife",
         "origin_base_url": "fallout4.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Fallout+4+Wiki"
-      }
+      },
       {
         "origin": "Fallout 76 Wiki - Fextralife",
         "origin_base_url": "fallout76.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Fallout+76+Wiki"
-      }
+      },
     ],
     "destination": "Independent Fallout Wiki",
     "destination_base_url": "fallout.wiki",
@@ -2902,13 +2902,13 @@
         "origin_base_url": "hollowknight.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Hollow+Knight+Wiki"
-      }
+      },
       {
         "origin": "Hollow Knight Silksong Fextralife Wiki",
         "origin_base_url": "hollowknightsilksong.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Hollow+Knight+Silksong+Wiki"
-      }
+      },
     ],
     "destination": "Hollow Knight Wiki",
     "destination_base_url": "hollowknight.wiki",
@@ -3745,13 +3745,13 @@
         "origin_base_url": "minecraft.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
-      }
+      },
       {
         "origin": "Minecraft Dungeons Wiki - Fextralife",
         "origin_base_url": "minecraftdungeons.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Minecraft+Dungeons+Wiki"
-      }
+      },
     ],
     "destination": "Minecraft Wiki",
     "destination_base_url": "minecraft.wiki",
@@ -6785,13 +6785,13 @@
         "origin_base_url": "zelda.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
-      }
+      },
       {
         "origin": "Zelda Tears of the Kingdom Wiki - Fextralife",
         "origin_base_url": "zeldatearsofthekingdom.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Zelda+Tears+of+the+Kingdom+Wiki"
-      }
+      },
     ],
     "destination": "Zelda Wiki",
     "destination_base_url": "zeldawiki.wiki",

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1362,13 +1362,19 @@
   },
   {
     "id": "en-darkestdungeon",
-    "origins_label": "Darkest Dungeon Fandom Wiki",
+    "origins_label": "Darkest Dungeon Fandom & Fextra Wikis",
     "origins": [
       {
         "origin": "Darkest Dungeon Fandom Wiki",
         "origin_base_url": "darkestdungeon.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Darkest_Dungeon_Wiki"
+      }
+      {
+        "origin": "Darkest Dungeon 2 Wiki - Fextralife",
+        "origin_base_url": "darkestdungeon2.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Darkest+Dungeon+2+Wiki"
       }
     ],
     "destination": "Darkest Dungeon Wiki",
@@ -1431,7 +1437,7 @@
   },
   {
     "id": "en-destiny",
-    "origins_label": "Destiny Fandom & Neoseeker Wikis",
+    "origins_label": "Destiny Fandom, Neoseeker & Fextra Wikis",
     "origins": [
       {
         "origin": "Destiny Fandom Wiki",
@@ -1444,6 +1450,18 @@
         "origin_base_url": "destiny.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
+      }
+      {
+        "origin": "Destiny Wiki - Fextralife",
+        "origin_base_url": "destiny.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Destiny+Wiki"
+      }
+      {
+        "origin": "Destiny 2 Wiki - Fextralife",
+        "origin_base_url": "destiny2.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Destiny+2+Wiki"
       }
     ],
     "destination": "Destinypedia",
@@ -2043,7 +2061,7 @@
   },
   {
     "id": "en-fallout",
-    "origins_label": "Fallout Fandom & Neoseeker Wikis",
+    "origins_label": "Fallout Fandom, Neoseeker & Fextralife Wikis",
     "origins": [
       {
         "origin": "Fallout Fandom Wiki (Nukapedia)",
@@ -2062,6 +2080,18 @@
         "origin_base_url": "fallout.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
+      }
+      {
+        "origin": "Fallout 4 Wiki - Fextralife",
+        "origin_base_url": "fallout4.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Fallout+4+Wiki"
+      }
+      {
+        "origin": "Fallout 76 Wiki - Fextralife",
+        "origin_base_url": "fallout76.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Fallout+76+Wiki"
       }
     ],
     "destination": "Independent Fallout Wiki",
@@ -2872,6 +2902,12 @@
         "origin_base_url": "hollowknight.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Hollow+Knight+Wiki"
+      }
+      {
+        "origin": "Hollow Knight Silksong Fextralife Wiki",
+        "origin_base_url": "hollowknightsilksong.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Hollow+Knight+Silksong+Wiki"
       }
     ],
     "destination": "Hollow Knight Wiki",
@@ -3709,6 +3745,12 @@
         "origin_base_url": "minecraft.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
+      }
+      {
+        "origin": "Minecraft Dungeons Wiki - Fextralife",
+        "origin_base_url": "minecraftdungeons.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Minecraft+Dungeons+Wiki"
       }
     ],
     "destination": "Minecraft Wiki",
@@ -6724,7 +6766,7 @@
   },
   {
     "id": "en-zelda",
-    "origins_label": "Zelda Fandom & Neoseeker Wikis",
+    "origins_label": "Zelda Fandom, Neoseeker, & Fextra Wikis",
     "origins": [
       {
         "origin": "Zelda Fandom Wiki",
@@ -6743,6 +6785,12 @@
         "origin_base_url": "zelda.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
+      }
+      {
+        "origin": "Zelda Tears of the Kingdom Wiki - Fextralife",
+        "origin_base_url": "zeldatearsofthekingdom.wiki.fextralife.com",
+        "origin_content_path": "/",
+        "origin_main_page": "Zelda+Tears+of+the+Kingdom+Wiki"
       }
     ],
     "destination": "Zelda Wiki",


### PR DESCRIPTION
Added Redirects for:

- Fallout 4 & 76 Fextra wikis to Independent Fallout Wiki
- Minecraft Dungeons Fextra to the Minecraft Wiki
- TOTK Fextra to Zeldapedia
- Darkest Dungeon 2 Fextra to Darkest Dungeon Wiki.gg
- Hollow Knight Silksong Fextra to Hollow Knight Wiki
- Destiny Fextras to Destinypedia