### PR TITLE
Fix path for the dota 2 wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1738,8 +1738,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "liquipediadota2wiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/dota2/index.php",
-    "destination_content_path": "/dota2/"
+    "destination_search_path": "/dota2game/index.php",
+    "destination_content_path": "/dota2game/"
   },
   {
     "id": "en-dotflow",


### PR DESCRIPTION
There's two dota wikis hosted by liquipedia:
- The e-sports wiki at https://liquipedia.net/dota2/Special:Version
- The game wiki at https://liquipedia.net/dota2game/Special:Version

The fandom wiki that moved is the game wiki and not the esports wiki, this fixes the path to be the correct one. Favicon is the same for both wikis.