### PR TITLE
Added Minecraft Story Mode Fandom Wiki Redirect

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -3901,6 +3901,12 @@
         "origin_base_url": "minecraftdungeons.wiki.fextralife.com",
         "origin_content_path": "/",
         "origin_main_page": "Minecraft+Dungeons+Wiki"
+      },
+      {
+        "origin": "Minecraft Story Mode Fandom Wiki",
+        "origin_base_url": "minecraftstorymode.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Minecraft_Story_Mode_Wiki"
       }
     ],
     "destination": "Minecraft Wiki",


### PR DESCRIPTION
Self-Explanatory, upon discovery of the Minecraft Story Mode Fandom, I created a redirect from it to the Minecraft Wiki.