### PR TITLE
re-ordering: unconditionally check for first result = indie wiki

### DIFF
--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -19,7 +19,7 @@ function addDOMChangeObserver(callback, searchEngine, storage) {
   const wrappedCallback = (mutations, observer) => {
     callback(searchEngine, storage, mutations, observer);
   };
-  
+
   const domObserver = new MutationObserver(wrappedCallback);
   domObserver.observe(document.body, config);
 }
@@ -561,17 +561,17 @@ async function reorderSearchResults(searchResults, searchEngine, storage) {
         // Handle re-ordering of results to move destination results up the page
         let matchingDest = await commonFunctionFindMatchingSite(searchResultLink, crossLanguageSetting, true);
         if (matchingDest) {
+          if (resultsFirstChild.contains(searchResult)) {
+            // If this search result is inside the first child of the results container (aka, it's the first result),
+            // and there is a matchingDest at this point, then an indie wiki is #1 on the search results page.
+            // Therefore, we should abandon the search re-ordering.
+            console.debug('Indie Wiki Buddy is not re-ordering results, as an indie wiki is already the first result.');
+            break;
+          }
+
           let searchEngineSettings = await commonFunctionDecompressJSON(storage.searchEngineSettings || {});
           if (searchEngineSettings[matchingDest.id] !== 'disabled') {
-            if (resultsFirstChild.contains(searchResult)) {
-              // If this search result is inside the first child of the results container (aka, it's the first result),
-              // and there is a matchingDest at this point, then an indie wiki is #1 on the search results page.
-              // Therefore, we should abandon the search re-ordering.
-              console.debug('Indie Wiki Buddy is not re-ordering results, as an indie wiki is already the first result.');
-              break;
-            } else {
-              resultsToSort.push(searchResult);
-            }
+            resultsToSort.push(searchResult);
           }
         }
       } catch (e) {


### PR DESCRIPTION
This check should be moved outside of the searchEngineSettings if statement, because the result of it should be applied regardless of the searchEngineSettings.