### PR TITLE
Removed Heroes Wiki, added another Doctor Who redirect, tagged Abiotic Factor as official

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -65,7 +65,9 @@
     "destination_search_path": "/index.php",
     "destination_content_path": "/wiki/",
     "tags": [
-      "wiki.gg"
+      "wiki.gg",
+      "official"
+    ]
     ]
   },
   {
@@ -3213,25 +3215,6 @@
     "tags": [
       "wiki.gg"
     ]
-  },
-  {
-    "id": "en-heroes",
-    "origins_label": "Heroes Fandom Wiki",
-    "origins": [
-      {
-        "origin": "Heroes Fandom Wiki",
-        "origin_base_url": "heroes.fandom.com",
-        "origin_content_path": "/wiki/",
-        "origin_main_page": "Heroes_Wiki"
-      }
-    ],
-    "destination": "Heroes Wiki",
-    "destination_base_url": "heroeswiki.ddns.net",
-    "destination_platform": "mediawiki",
-    "destination_icon": "heroeswiki.png",
-    "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php",
-    "destination_content_path": "/wiki/"
   },
   {
     "id": "en-hollowknight",

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -68,7 +68,6 @@
       "wiki.gg",
       "official"
     ]
-    ]
   },
   {
     "id": "en-acecombat",

--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -1822,6 +1822,12 @@
         "origin_base_url": "doctorwhothetimetravlingtardis.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Doctor_Who"
+      },
+      {
+        "origin": "K9tv Fandom Wiki",
+        "origin_base_url": "k9tv.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "K9tv_Wiki"
       }
     ],
     "destination": "Tardis (Doctor Who) Wiki",

--- a/data/sitesFR.json
+++ b/data/sitesFR.json
@@ -80,25 +80,6 @@
     "destination_content_path": "/index.php?title="
   },
   {
-    "id": "fr-heroes",
-    "origins_label": "Heroes Fandom Wiki",
-    "origins": [
-      {
-        "origin": "Heroes Fandom Wiki",
-        "origin_base_url": "heroes.fandom.com/fr",
-        "origin_content_path": "/wiki/",
-        "origin_main_page": "Accueil_Heroes"
-      }
-    ],
-    "destination": "Heroes Wiki",
-    "destination_base_url": "fr.heroeswiki.ddns.net",
-    "destination_platform": "mediawiki",
-    "destination_icon": "heroeswiki.png",
-    "destination_main_page": "Accueil",
-    "destination_search_path": "/index.php",
-    "destination_content_path": "/wiki/"
-  },
-  {
     "id": "fr-minecraft",
     "origins_label": "Minecraft Fandom Wikis",
     "origins": [


### PR DESCRIPTION
Removed the French and English redirects for the independent wiki of the 2000s TV show Heroes due to an error on the wiki's side rendering it inoperable. Also, I forgot to mark the Abiotic Factor wiki.gg as official.

And now I've added _another_ redirect to TARDIS Wiki.