### PR TITLE
Perf: Rewrite content scripts to run at the start of document/page loading

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -289,8 +289,8 @@
     "description": "Option to show a banner when non-indie results are hidden"
   },
   "settingsReorderResults": {
-    "message": "On Google, move indie wikis above non-indie results and hide duplicates",
-    "description": "Option to move indie wikis above non-indie results and hide duplicates on Google"
+    "message": "Move indie wikis above non-indie results and hide duplicates (Excluding Brave)",
+    "description": "Option to move indie wikis above non-indie results and hide duplicates (Excluding Brave)"
   },
   "settingsBreezeWiki": {
     "message": "BreezeWiki alternative frontend for Fandom ($linkStart$learn more$linkEnd$)",

--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -285,7 +285,7 @@
       "css": [
         "css/content-search-filtering.css"
       ],
-      "run_at": "document_end"
+      "run_at": "document_start"
     },
     {
       "matches": [
@@ -374,6 +374,9 @@
     "https://breeze.whateveritworks.org/*",
     "https://breezewiki.woodland.cafe/*"
   ],
+  "options_ui": {
+    "page": "pages/settings/index.html"
+  },
   "optional_host_permissions": ["https://*/*"],
   "minimum_chrome_version": "88",
   "manifest_version": 3

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -70,7 +70,10 @@
     "data/sitesZH.json"
   ],
   "background": {
-    "scripts": ["scripts/common-functions.js", "background.js"],
+    "scripts": [
+      "scripts/common-functions.js",
+      "background.js"
+    ],
     "persistent": true
   },
   "content_scripts": [
@@ -99,8 +102,13 @@
         "https://breeze.whateveritworks.org/*",
         "https://breezewiki.woodland.cafe/*"
       ],
-      "js": ["scripts/common-functions.js", "scripts/content-banners.js"],
-      "css": ["css/content-banners.css"],
+      "js": [
+        "scripts/common-functions.js",
+        "scripts/content-banners.js"
+      ],
+      "css": [
+        "css/content-banners.css"
+      ],
       "run_at": "document_start"
     },
     {
@@ -125,7 +133,10 @@
         "https://breeze.whateveritworks.org/*",
         "https://breezewiki.woodland.cafe/*"
       ],
-      "js": ["scripts/common-functions.js", "scripts/content-breezewiki.js"],
+      "js": [
+        "scripts/common-functions.js",
+      "scripts/content-breezewiki.js"
+    ],
       "run_at": "document_end"
     },
     {
@@ -348,8 +359,13 @@
         "https://www.google.co.zw/search*",
         "https://www.google.cat/search*"
       ],
-      "js": ["scripts/common-functions.js", "scripts/content-search-filtering.js"],
-      "css": ["css/content-search-filtering.css"],
+      "js": [
+        "scripts/common-functions.js",
+      "scripts/content-search-filtering.js"
+    ],
+      "css": [
+        "css/content-search-filtering.css"
+    ],
       "run_at": "document_start"
     }
   ],

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -70,10 +70,7 @@
     "data/sitesZH.json"
   ],
   "background": {
-    "scripts": [
-      "scripts/common-functions.js",
-      "background.js"
-    ],
+    "scripts": ["scripts/common-functions.js", "background.js"],
     "persistent": true
   },
   "content_scripts": [
@@ -102,13 +99,8 @@
         "https://breeze.whateveritworks.org/*",
         "https://breezewiki.woodland.cafe/*"
       ],
-      "js": [
-        "scripts/common-functions.js",
-        "scripts/content-banners.js"
-      ],
-      "css": [
-        "css/content-banners.css"
-      ],
+      "js": ["scripts/common-functions.js", "scripts/content-banners.js"],
+      "css": ["css/content-banners.css"],
       "run_at": "document_start"
     },
     {
@@ -133,10 +125,7 @@
         "https://breeze.whateveritworks.org/*",
         "https://breezewiki.woodland.cafe/*"
       ],
-      "js": [
-        "scripts/common-functions.js",
-        "scripts/content-breezewiki.js"
-      ],
+      "js": ["scripts/common-functions.js", "scripts/content-breezewiki.js"],
       "run_at": "document_end"
     },
     {
@@ -359,16 +348,14 @@
         "https://www.google.co.zw/search*",
         "https://www.google.cat/search*"
       ],
-      "js": [
-        "scripts/common-functions.js",
-        "scripts/content-search-filtering.js"
-      ],
-      "css": [
-        "css/content-search-filtering.css"
-      ],
-      "run_at": "document_end"
+      "js": ["scripts/common-functions.js", "scripts/content-search-filtering.js"],
+      "css": ["css/content-search-filtering.css"],
+      "run_at": "document_start"
     }
   ],
+  "options_ui": {
+    "page": "pages/settings/index.html"
+  },
   "optional_permissions": ["https://*/*"],
   "browser_specific_settings": {
     "gecko": {

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -126,16 +126,23 @@ async function populateSiteDataByOrigin() {
   return sites;
 }
 
+/** @type {SiteData[] | Promise<SiteData[]> | undefined} */
+let _siteDataByOrigin;
+
 /**
  * Load wiki data objects, with each origin having its own object
  * @returns {Promise<SiteData[]>}
  */
 async function commonFunctionGetSiteDataByOrigin() {
-  if (typeof window === 'undefined' || !window.iwb_siteDataByOrigin || window.iwb_siteDataByOrigin.length === 0) {
+  if (_siteDataByOrigin === undefined) {
+    let resolve;
+    _siteDataByOrigin = new Promise(_resolve => resolve = _resolve);
     let sites = await populateSiteDataByOrigin();
+    resolve(sites);
+    console.debug("IWB: Site data loaded.");
     return sites;
   } else {
-    return window.iwb_siteDataByOrigin;
+    return _siteDataByOrigin;
   }
 }
 
@@ -148,32 +155,31 @@ async function commonFunctionGetSiteDataByOrigin() {
 async function commonFunctionFindMatchingSite(site, crossLanguageSetting, dest = false) {
   let base_url_key = dest ? 'destination_base_url' : 'origin_base_url';
 
-  let matchingSite = commonFunctionGetSiteDataByOrigin().then(sites => {
-    let matchingSites = [];
-    if (crossLanguageSetting === 'on') {
-      matchingSites = sites.filter(el => site.replace(/.*https?:\/\//, '').startsWith(el[base_url_key]));
-    } else {
-      matchingSites = sites.filter(el =>
-        site.replace(/.*https?:\/\//, '').startsWith(dest ? el[base_url_key] : (el.origin_base_url + el.origin_content_path))
-        || site.replace(/.*https?:\/\//, '').replace(/\/$/, '') === el[base_url_key]
-      );
-    }
+  let sites = await commonFunctionGetSiteDataByOrigin();
 
-    if (matchingSites.length > 0) {
-      // Select match with longest base URL
-      let closestMatch = '';
-      matchingSites.forEach(site => {
-        if (site[base_url_key].length > closestMatch.length) {
-          closestMatch = site[base_url_key];
-        }
-      });
-      return matchingSites.find(site => site[base_url_key] === closestMatch) ?? null;
-    } else {
-      return null;
-    }
-  });
+  let matchingSites = [];
+  if (crossLanguageSetting === 'on') {
+    matchingSites = sites.filter(el => site.replace(/.*https?:\/\//, '').startsWith(el[base_url_key]));
+  } else {
+    matchingSites = sites.filter(
+      el =>
+        site.replace(/.*https?:\/\//, '').startsWith(dest ? el[base_url_key] : el.origin_base_url + el.origin_content_path) ||
+        site.replace(/.*https?:\/\//, '').replace(/\/$/, '') === el[base_url_key]
+    );
+  }
 
-  return matchingSite;
+  if (matchingSites.length > 0) {
+    // Select match with longest base URL
+    let closestMatch = '';
+    matchingSites.forEach(site => {
+      if (site[base_url_key].length > closestMatch.length) {
+        closestMatch = site[base_url_key];
+      }
+    });
+    return matchingSites.find(site => site[base_url_key] === closestMatch) ?? null;
+  } else {
+    return null;
+  }
 }
 
 /**
@@ -321,6 +327,12 @@ async function commonFunctionMigrateToV3() {
       extensionAPI.storage.sync.set({ 'v3migration': 'done' });
     }
   });
+}
+
+/** @param {Node} element */
+function isAnchor(element) {
+  if (!element instanceof HTMLElement) return false;
+  return element.tagName && element.tagName.toLowerCase() === 'a';
 }
 
 /**

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -331,7 +331,7 @@ async function commonFunctionMigrateToV3() {
 
 /** @param {Node} element */
 function isAnchor(element) {
-  if (!element instanceof HTMLElement) return false;
+  if (!(element instanceof HTMLElement)) return false;
   return element.tagName && element.tagName.toLowerCase() === 'a';
 }
 

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -768,20 +768,24 @@ async function decompressStorage(storage) {
 function processSearchEngine(_searchEngine) {
   searchEngine = _searchEngine;
   console.debug('Indie Wiki Buddy: Processing search engine:', searchEngine);
-  extensionAPI.runtime.sendMessage({ action: 'getStorage' }, /** @param {Record<string, any>} _storage */ async (_storage) => {
-    console.debug('IWB: Storage acquired.');
-    storage = await decompressStorage(_storage ?? {});
-    console.debug('IWB: storage decompressed.');
-    const searchEngineToggles = storage.searchEngineToggles ?? {};
-    if (searchEngineToggles[searchEngine] === 'on' || !searchEngineToggles.hasOwnProperty(searchEngine)) {
-      // catchup on any possible missed search results
-      checkRevalidate();
-      filterAnchors(Array.from(document.body?.querySelectorAll('a') ?? []));
+  extensionAPI.runtime.sendMessage(
+    { action: 'getStorage' },
+    /** @param {Record<string, any>} _storage */ async _storage => {
+      console.debug('IWB: Storage acquired.');
+      storage = await decompressStorage(_storage ?? {});
+      console.debug('IWB: storage decompressed.');
+      const searchEngineToggles = storage.searchEngineToggles ?? {};
+      if ((storage.power ?? 'on') != 'on') return;
+      if (searchEngineToggles[searchEngine] === 'on' || !searchEngineToggles.hasOwnProperty(searchEngine)) {
+        // catchup on any possible missed search results
+        checkRevalidate();
+        filterAnchors(Array.from(document.body?.querySelectorAll('a') ?? []));
 
-      // start listening to DOM changes
-      addDOMChangeObserver(filterMutations);
+        // start listening to DOM changes
+        addDOMChangeObserver(filterMutations);
+      }
     }
-  });
+  );
 }
 
 // fill cache

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -5,7 +5,7 @@
 const currentURL = new URL(document.location.href);
 let hiddenWikisRevealed = {};
 
-/** @type {{url: string, isNonIndie: boolean, siteData: SiteData, container: HTMLElement}[]} */
+/** @type {{url: string, isNonIndie: boolean, siteData: SiteData, container: HTMLElement, anchor: HTMLAnchorElement}[]} */
 const processedCache = [];
 
 /** @type {string} */
@@ -273,21 +273,17 @@ function mountSearchBanner(wikiInfo) {
  * @param {string} bannerState
  */
 function hideSearchResults(searchResultContainer, wikiInfo, bannerState = 'on') {
-  if (!searchResultContainer.classList.contains('iwb-detected')) {
-    let elementId = stringToId(wikiInfo.language + '-' + wikiInfo.origin);
-    searchResultContainer.classList.add('iwb-search-result-' + elementId);
-    searchResultContainer.classList.add('iwb-detected');
-    const revealed = hiddenWikisRevealed[elementId] ?? false;
-    searchResultContainer.classList.toggle('iwb-hide', !revealed);
-    searchResultContainer.classList.toggle('iwb-show', revealed);
+  let elementId = stringToId(wikiInfo.language + '-' + wikiInfo.origin);
+  searchResultContainer.classList.add('iwb-search-result-' + elementId);
+  const revealed = hiddenWikisRevealed[elementId] ?? false;
+  searchResultContainer.classList.toggle('iwb-hide', !revealed);
+  searchResultContainer.classList.toggle('iwb-show', revealed);
 
-    if (bannerState === 'on') {
-      mountSearchBanner(wikiInfo);
-    }
-    return 1;
+  if (bannerState === 'on') {
+    mountSearchBanner(wikiInfo);
   }
 
-  return 0;
+  return 1;
 }
 
 /**
@@ -494,7 +490,8 @@ async function filterSearchResults(searchResults) {
             url: searchResultLink,
             isNonIndie: true,
             siteData: matchingNonIndieWiki,
-            container: searchResultContainer
+            container: searchResultContainer,
+            anchor: searchResult,
           });
         } else {
           // handle destination -> source, i.e. indie wikis
@@ -506,7 +503,8 @@ async function filterSearchResults(searchResults) {
               url: searchResultLink,
               isNonIndie: false,
               siteData: matchingIndieWiki,
-              container: searchResultContainer
+              container: searchResultContainer,
+              anchor: searchResult,
             };
 
             if ((storage.reorderResults ?? 'on') == 'on' && processedCache[0]?.isNonIndie) {
@@ -516,6 +514,9 @@ async function filterSearchResults(searchResults) {
               const old = processedCache[0];
               processedCache[0] = cacheInfo;
               processedCache.push(old);
+
+              // re-filter the element that was swapped
+              countFiltered += filterSearchResult(old.siteData, old.anchor);
             } else {
               processedCache.push(cacheInfo);
             };


### PR DESCRIPTION
In using Indie Wiki Buddy, I noticed that it only reorganizes/filters search results *after* the document has loaded (i.e. run_at = document_end), and I thought it might be nice to have it run at the start, rather than the end.

This PR rewrites the content scripts to follow with the paradigm of MutationObservers, and 'streaming' new anchor elements that have been added to the page to be processed and filtered. 

In doing so, this PR also cleans up some of the main content script logic, so hopefully although a lot of code was changed, the new structure of the code should make it easier for newcomers to understand what it's doing, and I hope also easier to review 😅.

## Features/fixes that this PR provides:

- Immediate filtering of search results
- (Reordering) If the first result is a fandom link, swaps it with (if one exists) a lower down indie wiki
- Reordering now works on all search engines! The only issue I've noticed is that Brave hydrates it's DOM, so the descriptions become a little wonky and are getting reset)
- Only ever execute on changed elements
- Search engines (such as bing) which do not reload on search changes still work, and the extension is able to detect when a new search is made and re-initialize it's internal url cache. This should also make the extension more stable in the long-run.

## Current issues:

- Ecosia still needs to run at document_end—there is some race condition where sometimes Ecosia's JS will crash based on DOM modifications made by the extension.
- The aforementioned reordering not working perfectly on Brave. Not sure whether to just turn it off on Brave, or let it stay with a notice. I'll leave that up to you :)

## Showcase:

Before:
https://github.com/user-attachments/assets/583b05d8-afbd-4bbd-bfe5-69eec712b323

After:
https://github.com/user-attachments/assets/0b8b56f2-3212-4a7b-9e64-354075d5a51f
