### PR TITLE
Refactor Settings page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -524,7 +524,7 @@
       }
     }
   },
-  "settingsDisableFor": {
+  "settingsDisabledFor": {
     "message": "Do nothing for $origin$",
     "description": "Tooltip for option to disable any action for a specific wiki",
     "placeholders": {

--- a/css/common.css
+++ b/css/common.css
@@ -270,18 +270,6 @@ select {
 }
 
 /* CONTROL CLASSES */
-.visuallyHidden {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  padding: 0 !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  white-space: nowrap !important;
-  border: 0 !important;
-}
-
 .text-sm {
   font-size: .85em;
 }

--- a/css/settings.css
+++ b/css/settings.css
@@ -35,15 +35,15 @@ legend {
   display: inline-block;
 }
 
-#legend div,
-#legend span {
-  padding: 0 0 0 8px;
+#legend > span {
+  margin-left: 8px;
 }
 
-#legend div {
+#legend > div {
+  margin-left: 16px;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 1em;
 }
 
 /* WIKI FILTERS */

--- a/css/settings.css
+++ b/css/settings.css
@@ -92,7 +92,7 @@ legend {
   filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.5));
 }
 
-.toggles label {
+.toggles .inputsContainer * {
   display: flex;
   align-items: center;
 }
@@ -237,22 +237,20 @@ button#setAllSearchEngineHide {
   text-align: center;
 }
 
-.inputsContainer>label,
-.inputsContainer>div {
+.inputsContainer>* {
   width: 20px;
   display: flex;
   text-align: center;
   justify-content: center;
 }
 
-.togglesHeader .inputsContainer>div:nth-child(4),
-.toggles>div>div>label:nth-child(4) {
+.inputsContainer>:nth-child(4) {
   padding-left: 5px;
   border-left: 1px solid var(--base-color-outline-light);
 }
 
-.inputsContainer label:nth-child(1) input,
-.inputsContainer label:nth-child(4) input {
+.inputsContainer input.toggleWikiDisabled,
+.inputsContainer input.toggleSeachEngineDisabled {
   accent-color: var(--disabled-color);
 }
 

--- a/css/settings.css
+++ b/css/settings.css
@@ -75,84 +75,60 @@ legend {
   }
 }
 
-/** TOGGLE OPTIONS **/
-.toggles {
-  font-size: 0.8rem;
-  white-space: nowrap;
-  position: relative;
+/** TOGGLE TABLE OPTIONS **/
+#toggles {
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
 }
 
-.toggles img {
-  line-height: 1.2rem;
+#toggles col.icon-col {
+  width: 1.75rem;
 }
 
-.toggles a img {
-  padding-right: .5rem;
-  vertical-align: middle;
-  filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.5));
+#toggles col.button-col {
+  width: 1.75rem;
 }
 
-.toggles .inputsContainer * {
-  display: flex;
-  align-items: center;
+#toggles col:nth-child(4 of .button-col) {
+  padding-left: 5px;
+  border-left: 1px solid var(--base-color-outline-light);
 }
 
-.toggles input {
-  cursor: pointer;
-  margin: 0;
-}
-
-.toggles>div {
-  display: flex;
-  flex-direction: row;
-  padding: 0 .5rem;
-  min-height: 20px;
-}
-
-.toggles .inputsContainer {
-  display: flex;
-  width: 150px;
-  justify-content: space-between;
-}
-
-.togglesHeader {
+#toggles thead {
   border-bottom: 1px solid var(--base-color-outline);
   background-color: var(--base-color-secondary);
 }
 
-.togglesHeader span {
-  flex: 1;
-  text-align: right;
-  font-style: italic;
-  margin-right: 1em;
-  padding: .75em 0;
+#togglesColumnLabels th {
+  padding: 5px;
+  font-weight: 600;
+  font-size: .9em;
   white-space: break-spaces;
+  line-height: initial;
+  text-align: center;
 }
 
-.toggles:not(.togglesHeader) span {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding: .5em 0;
-}
-
-#toggles>div:hover {
-  background-color: var(--base-color-primary-dark);
+#toggles thead tr th[scope="row"] {
+  text-align: right;
+  font-weight: normal;
+  font-style: italic;
+  padding: .5em;
+  white-space: break-spaces;
 }
 
 #togglesKeys button {
   all: unset;
-  display: inline-flex;
-  vertical-align: middle;
-  width: 100%;
-  height: 100%;
+  width: var(--default-icon-size);
+  height: var(--default-icon-size);
   background-repeat: no-repeat;
   background-position: center;
   background-size: var(--default-icon-size);
   cursor: pointer;
 }
 
-button#setAllWikiDisabled {
+button#setAllWikiDisabled,
+button#setAllSearchEngineDisabled {
   background-image: url('../../images/toggle-disabled.png');
 }
 
@@ -162,10 +138,6 @@ button#setAllWikiAlert {
 
 button#setAllWikiRedirect {
   background-image: url('../../images/toggle-redirect.png');
-}
-
-button#setAllSearchEngineDisabled {
-  background-image: url('../../images/toggle-disabled.png');
 }
 
 button#setAllSearchEngineReplace {
@@ -181,76 +153,75 @@ button#setAllSearchEngineHide {
 }
 
 #togglesDefaults input[type=radio] {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-#togglesDefaults input+label {
-  width: 100%;
-  height: 100%;
+  appearance: none;
+  width: var(--default-icon-size);
+  height: var(--default-icon-size);
   background-image: url('../../images/star-off.png');
   background-repeat: no-repeat;
   background-position: center;
   background-size: var(--default-icon-size);
 }
 
-#togglesDefaults input:checked+label {
+#togglesDefaults input[type=radio]:checked {
   background-image: url('../../images/star-on.png');
 }
 
-#togglesDefaults label {
-  cursor: pointer;
-}
-
-#togglesKeys .inputsContainer button:hover::after,
-#togglesDefaults .inputsContainer label:hover::after {
+#togglesKeys button:hover::after,
+#togglesDefaults input:hover::after {
   content: attr(data-title);
   padding: 5px;
-  width: fit-content;
+  width: max-content;
   border: 1px solid var(--base-color-outline-dark);
   position: absolute;
   color: #fff;
   background: var(--base-color-dark);
+  font-size: 0.8rem;
   z-index: 999999;
+  left: 0px;
+  bottom: -20px;
   transform: translateX(calc(-100% - 5px));
-  top: 30px;
 }
 
-#togglesColumnLabels {
-  background-color: var(--base-color-secondary);
-  padding: 5px 0;
-}
-
-#togglesColumnLabels>div>div {
-  display: flex;
-  width: 150px;
-}
-
-#togglesColumnLabels>div>div>div {
-  flex: 1 1 0;
-  font-weight: 600;
-  font-size: .9em;
-  white-space: break-spaces;
-  line-height: initial;
+#toggles tr :has(input),
+#toggles tr :has(button) {
   text-align: center;
+  vertical-align: middle;
+  position: relative;
 }
 
-.inputsContainer>* {
-  width: 20px;
-  display: flex;
+#toggles input {
+  cursor: pointer;
+  margin: 0;
+}
+
+#toggles tbody tr:hover {
+  background-color: var(--base-color-primary-dark);
+}
+
+#toggles tbody {
+  font-size: 0.8rem;
   text-align: center;
-  justify-content: center;
+  vertical-align: middle;
 }
 
-.inputsContainer>:nth-child(4) {
-  padding-left: 5px;
-  border-left: 1px solid var(--base-color-outline-light);
+#toggles img {
+  line-height: 1.2rem;
 }
 
-.inputsContainer input.toggleWikiDisabled,
-.inputsContainer input.toggleSeachEngineDisabled {
+#toggles tbody tr td img {
+  filter: drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.5));
+}
+
+#toggles tbody .wiki-description {
+  white-space: nowrap;
+  text-align: left;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding: .5rem 0;
+}
+
+#toggles input.toggleWikiDisabled,
+#toggles input.toggleSearchEngineDisabled {
   accent-color: var(--disabled-color);
 }
 

--- a/css/settings.css
+++ b/css/settings.css
@@ -82,12 +82,19 @@ legend {
   width: 100%;
 }
 
-#toggles col.icon-col {
+#toggles col#icon-col,
+#toggles col.button-col {
   width: 1.75rem;
 }
 
-#toggles col.button-col {
-  width: 1.75rem;
+#toggles col#lang-col {
+  width: 2rem;
+  visibility: visible;
+}
+
+#toggles col#lang-col.hidden-col {
+  width: 0px;
+  visibility: collapse;
 }
 
 #toggles col:nth-child(4 of .button-col) {

--- a/css/settings.css
+++ b/css/settings.css
@@ -152,15 +152,15 @@ legend {
   cursor: pointer;
 }
 
-button#setAllDisabled {
+button#setAllWikiDisabled {
   background-image: url('../../images/toggle-disabled.png');
 }
 
-button#setAllAlert {
+button#setAllWikiAlert {
   background-image: url('../../images/toggle-alert.png');
 }
 
-button#setAllRedirect {
+button#setAllWikiRedirect {
   background-image: url('../../images/toggle-redirect.png');
 }
 

--- a/css/settings.css
+++ b/css/settings.css
@@ -73,10 +73,13 @@ legend {
 
 /** TOGGLE TABLE OPTIONS **/
 #toggles {
-  border-collapse: collapse;
+  --table-border-radius: 5px;
   table-layout: fixed;
   width: 100%;
-  background: var(--base-color-secondary);
+  background-color: var(--base-color-secondary);
+  border: 1px solid var(--base-color-outline-light);
+  border-radius: var(--table-border-radius);
+  border-spacing: 0px;
 }
 
 #toggles col#icon-col,
@@ -94,13 +97,15 @@ legend {
   visibility: collapse;
 }
 
-#toggles col:nth-child(4 of .button-col) {
-  padding-left: 5px;
-  border-left: 1px solid var(--base-color-outline-light);
+#toggles tr.togglesHeader td:nth-last-child(4),
+#toggles tr.site-container td:nth-last-child(4) {
+  padding-right: 2px;
 }
 
-#toggles thead {
-  background-color: var(--base-color-secondary);
+#toggles tr.togglesHeader td:nth-last-child(3),
+#toggles tr.site-container td:nth-last-child(3) {
+  padding-left: 2px;
+  border-left: 1px solid var(--base-color-outline-light);
 }
 
 #togglesColumnLabels th {
@@ -122,8 +127,25 @@ legend {
   font-size: .9rem;
 }
 
-#togglesDefaults tr {
+#toggles td,
+#toggles th {
   background-color: var(--base-color-secondary);
+}
+
+#toggles thead tr:first-child :first-child {
+  border-top-left-radius: var(--table-border-radius);
+}
+
+#toggles thead tr:first-child :last-child {
+  border-top-right-radius: var(--table-border-radius);
+}
+
+#toggles tbody tr:last-child :first-child {
+  border-bottom-left-radius: var(--table-border-radius);
+}
+
+#toggles tbody tr:last-child :last-child {
+  border-bottom-right-radius: var(--table-border-radius);
 }
 
 #togglesKeys button:hover::after,

--- a/css/settings.css
+++ b/css/settings.css
@@ -20,10 +20,6 @@ legend {
   padding: 1rem .75rem;
 }
 
-.site-container {
-  background: var(--base-color-secondary);
-}
-
 /* NOTIFICATIONS */
 #notificationBannerReviewLinks {
   display: flex;
@@ -80,6 +76,7 @@ legend {
   border-collapse: collapse;
   table-layout: fixed;
   width: 100%;
+  background: var(--base-color-secondary);
 }
 
 #toggles col#icon-col,
@@ -103,7 +100,6 @@ legend {
 }
 
 #toggles thead {
-  border-bottom: 1px solid var(--base-color-outline);
   background-color: var(--base-color-secondary);
 }
 
@@ -116,12 +112,34 @@ legend {
   text-align: center;
 }
 
-#toggles thead tr th[scope="row"] {
+#togglesKeys th,
+#togglesDefaults th {
   text-align: right;
   font-weight: normal;
   font-style: italic;
   padding: .5em;
   white-space: break-spaces;
+  font-size: .9rem;
+}
+
+#togglesDefaults tr {
+  background-color: var(--base-color-secondary);
+}
+
+#togglesKeys button:hover::after,
+#togglesDefaults input:hover::after {
+  content: attr(data-title);
+  padding: 5px;
+  width: max-content;
+  border: 1px solid var(--base-color-outline-dark);
+  position: absolute;
+  color: #fff;
+  background-color: var(--base-color-dark);
+  font-size: 0.8rem;
+  z-index: 999999;
+  left: 0px;
+  bottom: -20px;
+  transform: translateX(calc(-100% - 5px));
 }
 
 #togglesKeys button {
@@ -173,24 +191,8 @@ button#setAllSearchEngineHide {
   background-image: url('../../images/star-on.png');
 }
 
-#togglesKeys button:hover::after,
-#togglesDefaults input:hover::after {
-  content: attr(data-title);
-  padding: 5px;
-  width: max-content;
-  border: 1px solid var(--base-color-outline-dark);
-  position: absolute;
-  color: #fff;
-  background: var(--base-color-dark);
-  font-size: 0.8rem;
-  z-index: 999999;
-  left: 0px;
-  bottom: -20px;
-  transform: translateX(calc(-100% - 5px));
-}
-
-#toggles tr :has(input),
-#toggles tr :has(button) {
+#toggles tr td:has(input),
+#toggles tr td:has(button) {
   text-align: center;
   vertical-align: middle;
   position: relative;

--- a/pages/popup/index.html
+++ b/pages/popup/index.html
@@ -176,7 +176,7 @@
       </fieldset>
       <fieldset id="breezewikiSettings">
         <legend>
-          <span aria-hidden="true">༄</span>&nbsp;
+          <span aria-hidden="true">🍃</span>&nbsp;
           <span
             data-msg="settingsBreezeWiki"
             data-msg-ph-1="<a id='breeezwikiLearnMore' href='https://breezewiki.com/' target='_blank'>"

--- a/pages/popup/index.html
+++ b/pages/popup/index.html
@@ -176,8 +176,7 @@
       </fieldset>
       <fieldset id="breezewikiSettings">
         <legend>
-          <span aria-hidden="true">🍃</span>&nbsp;
-          <span
+          <span aria-hidden="true">🍃</span>&nbsp;<span
             data-msg="settingsBreezeWiki"
             data-msg-ph-1="<a id='breeezwikiLearnMore' href='https://breezewiki.com/' target='_blank'>"
             data-msg-ph-2="</a>"></span>

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -282,7 +282,8 @@
         </div>
         <table id="toggles" class="toggles">
           <colgroup>
-            <col class="icon-col" />
+            <col id="icon-col" />
+            <col id="lang-col" />
             <col />
             <col class="button-col" />
             <col class="button-col" />
@@ -293,12 +294,12 @@
           </colgroup>
           <thead id="togglesHeader" class="sticky">
             <tr id="togglesColumnLabels">
-              <td colspan="2"></td>
+              <td colspan="3"></td>
               <th colspan="3" scope="col" data-msg="settingsWikiExp"></th>
               <th colspan="3" scope="col" data-msg="settingsSearchExp"></th>
             </tr>
             <tr id="togglesKeys" class="toggles togglesHeader">
-              <th colspan="2" scope="row" data-msg="settingsSetColumn"></th>
+              <th colspan="3" scope="row" data-msg="settingsSetColumn"></th>
               <td>
                 <button id="setAllWikiDisabled" type="button" 
                 data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled"></button>
@@ -325,7 +326,7 @@
               </td>
             </tr>
             <tr id="togglesDefaults" class="toggles togglesHeader">
-              <th colspan="2" scope="row" data-msg="settingsNewWiki"></th>
+              <th colspan="3" scope="row" data-msg="settingsNewWiki"></th>
               <td>
                 <input id="defaultWikiActionDisabledRadio" type="radio" name="defaultWikiAction" value="disabled" 
                 data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled" />

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -280,87 +280,80 @@
             <input id="filterInput" type="text" name="filterInput" data-msg-attr="placeholder=settingsNameFilterPlaceholder" />
           </div>
         </div>
-        <div class="sticky">
-          <div id="togglesColumnLabels" class="toggles">
-            <div>
-              <span></span>
-              <div>
-                <div data-msg="settingsWikiExp"></div>
-                <div data-msg="settingsSearchExp"></div>
-              </div>
-            </div>
-          </div>
-          <div id="togglesKeys" class="toggles togglesHeader">
-            <div>
-              <span data-msg="settingsSetColumn"></span>
-              <div class="inputsContainer">
-                <div>
-                  <button id="setAllWikiDisabled" type="button" data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled">
-                  </button>
-                </div>
-                <div>
-                  <button id="setAllWikiAlert" type="button"  data-msg-attr="data-title=settingsAlert,aria-label=settingsAlert">
-                  </button>
-                </div>
-                <div>
-                  <button id="setAllWikiRedirect" type="button"  data-msg-attr="data-title=settingsRedirect,aria-label=settingsRedirect">
-                  </button>
-                </div>
-                <div>
-                  <button id="setAllSearchEngineDisabled" type="button" data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled">
-                  </button>
-                </div>
-                <div>
-                  <button id="setAllSearchEngineReplace" type="button"  data-msg-attr="data-title=settingsReplace,aria-label=settingsReplace">
-                  </button>
-                </div>
-                <div>
-                  <button id="setAllSearchEngineHide" type="button" data-msg-attr="data-title=settingsHide,aria-label=settingsHide">
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div id="togglesDefaults" class="toggles togglesHeader">
-          <div>
-            <span data-msg="settingsNewWiki"></span>
-            <div class="inputsContainer">
-              <div>
-                <input id="defaultWikiActionDisabledRadio" type="radio" name="defaultWikiAction" value="disabled"
-                  data-msg-attr="aria-label=settingsDisabled" />
-                <label data-msg-attr="data-title=settingsDisabled"
-                  for="defaultWikiActionDisabledRadio"></label>
-              </div>
-              <div>
-                <input id="defaultWikiActionAlertRadio" type="radio" name="defaultWikiAction" value="alert"
-                  data-msg-attr="aria-label=settingsAlert" />
-                <label data-msg-attr="data-title=settingsAlert" for="defaultWikiActionAlertRadio"></label>
-              </div>
-              <div>
-                <input id="defaultWikiActionRedirectRadio" type="radio" name="defaultWikiAction" value="redirect"
-                  data-msg-attr="aria-label=settingsRedirect" />
-                <label data-msg-attr="data-title=settingsRedirect" for="defaultWikiActionRedirectRadio"></label>
-              </div>
-              <div>
-                <input id="defaultSearchActionDisabledRadio" type="radio" name="defaultSearchAction" value="disabled"
-                  data-msg-attr="aria-label=settingsDisabled" />
-                <label data-msg-attr="data-title=settingsDisabled" for="defaultSearchActionDisabledRadio"></label>
-              </div>
-              <div>
-                <input id="defaultSearchActionReplaceRadio" type="radio" name="defaultSearchAction" value="replace"
-                  data-msg-attr="aria-label=settingsReplace" />
-                <label data-msg-attr="data-title=settingsReplace" for="defaultSearchActionReplaceRadio"></label>
-              </div>
-              <div>
-                <input id="defaultSearchActionHideRadio" type="radio" name="defaultSearchAction" value="hide"
-                  data-msg-attr="aria-label=settingsHide" />
-                <label data-msg-attr="data-title=settingsHide" for="defaultSearchActionHideRadio"></label>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div id="toggles" class="toggles"></div>
+        <table id="toggles" class="toggles">
+          <colgroup>
+            <col class="icon-col" />
+            <col />
+            <col class="button-col" />
+            <col class="button-col" />
+            <col class="button-col" />
+            <col class="button-col" />
+            <col class="button-col" />
+            <col class="button-col" />
+          </colgroup>
+          <thead id="togglesHeader" class="sticky">
+            <tr id="togglesColumnLabels">
+              <td colspan="2"></td>
+              <th colspan="3" scope="col" data-msg="settingsWikiExp"></th>
+              <th colspan="3" scope="col" data-msg="settingsSearchExp"></th>
+            </tr>
+            <tr id="togglesKeys" class="toggles togglesHeader">
+              <th colspan="2" scope="row" data-msg="settingsSetColumn"></th>
+              <td>
+                <button id="setAllWikiDisabled" type="button" 
+                data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled"></button>
+              </td>
+              <td>
+                <button id="setAllWikiAlert" type="button" 
+                data-msg-attr="data-title=settingsAlert,aria-label=settingsAlert"></button>
+              </td>
+              <td>
+                <button id="setAllWikiRedirect" type="button" 
+                data-msg-attr="data-title=settingsRedirect,aria-label=settingsRedirect"></button>
+              </td>
+              <td>
+                <button id="setAllSearchEngineDisabled" type="button" 
+                data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled"></button>
+              </td>
+              <td>
+                <button id="setAllSearchEngineReplace" type="button" 
+                data-msg-attr="data-title=settingsReplace,aria-label=settingsReplace"></button>
+              </td>
+              <td>
+                <button id="setAllSearchEngineHide" type="button" 
+                data-msg-attr="data-title=settingsHide,aria-label=settingsHide"></button>
+              </td>
+            </tr>
+            <tr id="togglesDefaults" class="toggles togglesHeader">
+              <th colspan="2" scope="row" data-msg="settingsNewWiki"></th>
+              <td>
+                <input id="defaultWikiActionDisabledRadio" type="radio" name="defaultWikiAction" value="disabled" 
+                data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled" />
+              </td>
+              <td>
+                <input id="defaultWikiActionAlertRadio" type="radio" name="defaultWikiAction" value="alert" 
+                data-msg-attr="data-title=settingsAlert,aria-label=settingsAlert" />
+              </td>
+              <td>
+                <input id="defaultWikiActionRedirectRadio" type="radio" name="defaultWikiAction" value="redirect" 
+                data-msg-attr="data-title=settingsRedirect,aria-label=settingsRedirect" />
+              </td>
+              <td>
+                <input id="defaultSearchActionDisabledRadio" type="radio" name="defaultSearchAction" value="disabled" 
+                data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled" />
+              </td>
+              <td>
+                <input id="defaultSearchActionReplaceRadio" type="radio" name="defaultSearchAction" value="replace" 
+                data-msg-attr="data-title=settingsReplace,aria-label=settingsReplace" />
+              </td>
+              <td>
+                <input id="defaultSearchActionHideRadio" type="radio" name="defaultSearchAction" value="hide" 
+                data-msg-attr="data-title=settingsHide,aria-label=settingsHide" />
+              </td>
+            </tr>
+          </thead>
+          <tbody id="togglesBody"></tbody>
+        </table>
       </form>
       <hr />
       <div id="footer">

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -325,6 +325,8 @@
                 data-msg-attr="data-title=settingsHide,aria-label=settingsHide"></button>
               </td>
             </tr>
+          </thead>
+          <tbody id="togglesBody">
             <tr id="togglesDefaults" class="toggles togglesHeader">
               <th colspan="3" scope="row" data-msg="settingsNewWiki"></th>
               <td>
@@ -352,8 +354,7 @@
                 data-msg-attr="data-title=settingsHide,aria-label=settingsHide" />
               </td>
             </tr>
-          </thead>
-          <tbody id="togglesBody"></tbody>
+          </tbody>
         </table>
       </form>
       <hr />

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -159,7 +159,7 @@
         </fieldset>
         <fieldset id="breezewikiSettings">
           <legend>
-            <span aria-hidden="true">༄</span>&nbsp;
+            <span aria-hidden="true">🍃</span>&nbsp;
             <span
               data-msg="settingsBreezeWiki"
               data-msg-ph-1="<a id='breeezwikiLearnMore' href='https://breezewiki.com/' target='_blank'>"

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -294,15 +294,15 @@
               <span data-msg="settingsSetColumn"></span>
               <div class="inputsContainer">
                 <div>
-                  <button id="setAllDisabled" type="button" data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled">
+                  <button id="setAllWikiDisabled" type="button" data-msg-attr="data-title=settingsDisabled,aria-label=settingsDisabled">
                   </button>
                 </div>
                 <div>
-                  <button id="setAllAlert" type="button"  data-msg-attr="data-title=settingsAlert,aria-label=settingsAlert">
+                  <button id="setAllWikiAlert" type="button"  data-msg-attr="data-title=settingsAlert,aria-label=settingsAlert">
                   </button>
                 </div>
                 <div>
-                  <button id="setAllRedirect" type="button"  data-msg-attr="data-title=settingsRedirect,aria-label=settingsRedirect">
+                  <button id="setAllWikiRedirect" type="button"  data-msg-attr="data-title=settingsRedirect,aria-label=settingsRedirect">
                   </button>
                 </div>
                 <div>

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -98,7 +98,9 @@
           </div>
         </fieldset>
         <fieldset id="generalSettings">
-          <legend><span aria-hidden="true">🔍</span>&nbsp;<span data-msg="settingsSearchEngineFiltering"></span></legend>
+          <legend>
+            <span aria-hidden="true">🔍</span>&nbsp;<span data-msg="settingsSearchEngineFiltering"></span>
+          </legend>
           <div class="settingToggle searchEngineToggles">
             <label>
               <input id="googleCheckbox" data-search-engine="google" type="checkbox" />
@@ -159,8 +161,7 @@
         </fieldset>
         <fieldset id="breezewikiSettings">
           <legend>
-            <span aria-hidden="true">🍃</span>&nbsp;
-            <span
+            <span aria-hidden="true">🍃</span>&nbsp;<span
               data-msg="settingsBreezeWiki"
               data-msg-ph-1="<a id='breeezwikiLearnMore' href='https://breezewiki.com/' target='_blank'>"
               data-msg-ph-2="</a>"></span>

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -52,6 +52,14 @@ async function loadOptions(lang, textFilter = '') {
     return a < b ? -1 : (a > b ? 1 : 0);
   });
 
+  // The language column is hidden when filtered to a specific language
+  const langCol = document.getElementById("lang-col");
+  if (lang === 'ALL') {
+    langCol.classList.remove("hidden-col");
+  } else {
+    langCol.classList.add("hidden-col");
+  }
+
   // Filter wikis by provided language and text filter
   sites = sites.filter((site) => (
     (lang === 'ALL' || site.language === lang) &&
@@ -181,6 +189,12 @@ async function loadOptions(lang, textFilter = '') {
         iconCell.appendChild(linkedIcon);
         siteRow.appendChild(iconCell);
 
+        // Create language tag (hidden unless filter is set to "All languages")
+        const languageSpan = document.createElement('td');
+        languageSpan.classList.add('text-sm');
+        languageSpan.innerText = `[${redirectEntry.language}]`;
+        siteRow.appendChild(languageSpan);
+
         // Create text description of the redirect
         const wikiLink = document.createElement("a");
         wikiLink.href = destinationSiteURL;
@@ -189,12 +203,6 @@ async function loadOptions(lang, textFilter = '') {
         wikiLink.appendChild(document.createTextNode(redirectEntry.destination));
 
         const wikiInfo = document.createElement('td');
-        if (lang === 'ALL') {
-          const languageSpan = document.createElement('span');
-          languageSpan.classList.add('text-sm');
-          languageSpan.innerText = ` [${redirectEntry.language}] `;
-          wikiInfo.appendChild(languageSpan);
-        }
         wikiInfo.classList.add('wiki-description');
         wikiInfo.appendChild(wikiLink);
         wikiInfo.appendChild(document.createTextNode(extensionAPI.i18n.getMessage('settingsWikiFrom', [sites[i].origins_label])));

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -36,18 +36,8 @@ function createRadioButton(redirectEntry, action, category) {
       extensionAPI.storage.sync.set({ [settingsType]: await commonFunctionCompressJSON(settings) });
     });
   });
-  
-  // Create a caption for the button
-  const buttonCaption = document.createElement('span');
-  buttonCaption.classList.add('visuallyHidden');
-  buttonCaption.textContent = displayText;
-  
-  // Add a <label> wrapper around the button and caption
-  const buttonWrapper = document.createElement("label");
-  buttonWrapper.appendChild(radioButton);
-  buttonWrapper.appendChild(buttonCaption);
 
-  return buttonWrapper;
+  return radioButton;
 }
 
 // Populate settings and toggles
@@ -130,20 +120,12 @@ async function loadOptions(lang, textFilter = '') {
         const redirectEntry = sites[i];
 
         // Create radio buttons for wiki & search engine options
-        const labelWikiDisabled = createRadioButton(redirectEntry, 'disabled', 'wiki');
-        const labelWikiAlert = createRadioButton(redirectEntry, 'alert', 'wiki');
-        const labelWikiRedirect = createRadioButton(redirectEntry, 'redirect', 'wiki');
-        const labelSearchEngineDisabled = createRadioButton(redirectEntry, 'disabled', 'searchEngine');
-        const labelSearchEngineReplace = createRadioButton(redirectEntry, 'replace', 'searchEngine');
-        const labelSearchEngineHide = createRadioButton(redirectEntry, 'hide', 'searchEngine');
-
-        // Get the radio buttons from within their wrappers
-        const inputWikiDisabled = labelWikiDisabled.firstChild;
-        const inputWikiAlert = labelWikiAlert.firstChild;
-        const inputWikiRedirect = labelWikiRedirect.firstChild;
-        const inputSearchEngineDisabled = labelSearchEngineDisabled.firstChild;
-        const inputSearchEngineReplace = labelSearchEngineReplace.firstChild;
-        const inputSearchEngineHide = labelSearchEngineHide.firstChild;
+        const inputWikiDisabled = createRadioButton(redirectEntry, 'disabled', 'wiki');
+        const inputWikiAlert = createRadioButton(redirectEntry, 'alert', 'wiki');
+        const inputWikiRedirect = createRadioButton(redirectEntry, 'redirect', 'wiki');
+        const inputSearchEngineDisabled = createRadioButton(redirectEntry, 'disabled', 'searchEngine');
+        const inputSearchEngineReplace = createRadioButton(redirectEntry, 'replace', 'searchEngine');
+        const inputSearchEngineHide = createRadioButton(redirectEntry, 'hide', 'searchEngine');
 
         // Set wiki radio buttons based on user's settings
         const wikiAction = wikiSettings[redirectEntry.id] ?? defaultWikiAction ?? 'alert';
@@ -207,17 +189,20 @@ async function loadOptions(lang, textFilter = '') {
         wikiInfo.appendChild(wikiLink);
         wikiInfo.appendChild(document.createTextNode(extensionAPI.i18n.getMessage('settingsWikiFrom', [sites[i].origins_label])));
 
-        // Output inputs container:
+        // Create inputs container:
         let inputsContainer = document.createElement('div');
         inputsContainer.classList = 'inputsContainer';
-        inputsContainer.appendChild(labelWikiDisabled);
-        inputsContainer.appendChild(labelWikiAlert);
-        inputsContainer.appendChild(labelWikiRedirect);
-        inputsContainer.appendChild(labelSearchEngineDisabled);
-        inputsContainer.appendChild(labelSearchEngineReplace);
-        inputsContainer.appendChild(labelSearchEngineHide);
 
-        let siteContainer = document.createElement("div");
+        // Wrap each of the buttons and add them to the container
+        const radioButtonArray = [inputWikiDisabled, inputWikiAlert, inputWikiRedirect, inputSearchEngineDisabled, inputSearchEngineReplace, inputSearchEngineHide];
+        for(radioButton of radioButtonArray) {
+          const buttonWrapper = document.createElement("div");
+          buttonWrapper.appendChild(radioButton);
+          inputsContainer.appendChild(buttonWrapper);
+        }
+
+        // Create row container
+        const siteContainer = document.createElement("div");
         siteContainer.classList.add('site-container')
 
         siteContainer.appendChild(wikiInfo);

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -131,51 +131,34 @@ async function loadOptions(lang, textFilter = '') {
         inputSearchEngineHide.lang = sites[i].language;
         inputSearchEngineHide.setAttribute('data-wiki-key', key);
 
-        // Check radio buttons based on user's settings
-        if (wikiSettings[key]) {
-          if (wikiSettings[key] === 'disabled') {
+        // Set wiki radio buttons based on user's settings
+        const wikiAction = wikiSettings[key] ?? defaultWikiAction ?? 'alert';
+        
+        switch(wikiAction) {
+          case 'disabled':
             inputDisabled.checked = true;
-          } else if (wikiSettings[key] === 'redirect') {
+            break;
+          case 'redirect':
             inputRedirect.checked = true;
-          } else {
+            break;
+          default:
             inputAlert.checked = true;
-          }
-        } else {
-          let actionSetting = defaultWikiAction;
-          if (actionSetting) {
-            if (actionSetting === 'disabled') {
-              inputDisabled.checked = true;
-            } else if (actionSetting === 'redirect') {
-              inputRedirect.checked = true;
-            } else {
-              inputAlert.checked = true;
-            }
-          } else {
-            inputAlert.checked = true;
-          }
         }
 
-        if (searchEngineSettings[key]) {
-          if (searchEngineSettings[key] === 'disabled') {
+        // Set search engine radio buttons based on user's settings
+        const searchEngineAction = searchEngineSettings[key] ?? defaultSearchAction ?? 'replace';
+
+        switch(searchEngineAction) {
+          case 'true':
+          case 'replace':
+            inputSearchEngineReplace.checked = true;
+            break;
+          case 'false':
+          case 'disabled':
             inputSearchEngineDisabled.checked = true;
-          } else if (searchEngineSettings[key] === 'replace') {
-            inputSearchEngineReplace.checked = true;
-          } else {
+            break;
+          default:
             inputSearchEngineHide.checked = true;
-          }
-        } else {
-          let actionSetting = defaultSearchAction;
-          if (actionSetting) {
-            if (actionSetting === 'true' || actionSetting === 'replace') {
-              inputSearchEngineReplace.checked = true;
-            } else if (actionSetting === 'false' || actionSetting === 'disabled') {
-              inputSearchEngineDisabled.checked = true;
-            } else {
-              inputSearchEngineHide.checked = true;
-            }
-          } else {
-            inputSearchEngineReplace.checked = true;
-          }
         }
 
         // Add listeners for when user clicks control:

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -174,7 +174,7 @@ async function loadOptions(lang, textFilter = '') {
 
         // Output wiki info:
         const destinationSiteURL = `https://${redirectEntry.destination_base_url}`;
-        const visitDestinationText = `Visit ${redirectEntry.destination}`;
+        const visitDestinationText = extensionAPI.i18n.getMessage('bannerVisit', [redirectEntry.destination]);
 
         // Create row container
         const siteRow = document.createElement("tr");
@@ -212,7 +212,7 @@ async function loadOptions(lang, textFilter = '') {
         const wikiInfo = document.createElement('td');
         wikiInfo.classList.add('wiki-description');
         wikiInfo.appendChild(wikiLink);
-        wikiInfo.appendChild(document.createTextNode(extensionAPI.i18n.getMessage('settingsWikiFrom', [sites[i].origins_label])));
+        wikiInfo.appendChild(document.createTextNode(extensionAPI.i18n.getMessage('settingsWikiFrom', [redirectEntry.origins_label])));
 
         siteRow.appendChild(wikiInfo);
 

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -1,4 +1,4 @@
-var sites = [];
+let sites = [];
 
 // Clear wiki toggles
 // Used when switching languages
@@ -66,73 +66,57 @@ async function loadOptions(lang, textFilter = '') {
       // Reset toggles:
       resetOptions();
 
+      function createRadioButton(site, title, buttonClass) {
+        const key = site.id;
+
+        let newButton = document.createElement("input");
+        newButton.classList = buttonClass;
+        newButton.type = "radio";
+        newButton.name = key + '-wiki-action';
+        newButton.title = title;
+        newButton.lang = site.language;
+        newButton.setAttribute('data-wiki-key', key);
+
+        return newButton;
+      }
+
       // Populate individual wiki settings:
       const toggleContainer = document.getElementById('toggles');
-      for (var i = 0; i < sites.length; i++) {
-        var key = sites[i].id;
+      for (let i = 0; i < sites.length; i++) {
+        const site = sites[i];
 
         // Create radio for disabling action on wiki:
         let labelDisabled = document.createElement("label");
-        let inputDisabled = document.createElement("input");
-        inputDisabled.classList = 'toggleDisable';
-        inputDisabled.type = "radio";
-        inputDisabled.name = key + '-wiki-action';
-        inputDisabled.title = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
-        inputDisabled.lang = sites[i].language;
-        inputDisabled.setAttribute('data-wiki-key', key);
+        const inputDisabledTitle = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
+        let inputDisabled = createRadioButton(site, inputDisabledTitle, 'toggleDisable');
 
         // Create radio for inserting banner on wiki:
         let labelAlert = document.createElement("label");
-        let inputAlert = document.createElement("input");
-        inputAlert.classList = 'toggleAlert';
-        inputAlert.type = "radio";
-        inputAlert.name = key + '-wiki-action';
-        inputAlert.title = extensionAPI.i18n.getMessage('settingsAlertFor', [sites[i].origins_label, sites[i].destination]);
-        inputAlert.lang = sites[i].language;
-        inputAlert.setAttribute('data-wiki-key', key);
+        const inputAlertTitle = extensionAPI.i18n.getMessage('settingsAlertFor', [sites[i].origins_label, sites[i].destination]);
+        let inputAlert = createRadioButton(site, inputAlertTitle, 'toggleAlert');
 
         // Create radio for redirecting wiki:
         let labelRedirect = document.createElement("label");
-        let inputRedirect = document.createElement("input");
-        inputRedirect.classList = 'toggleRedirect';
-        inputRedirect.type = "radio";
-        inputRedirect.name = key + '-wiki-action';
-        inputRedirect.title = extensionAPI.i18n.getMessage('settingsRedirectFor', [sites[i].origins_label, sites[i].destination]);
-        inputRedirect.lang = sites[i].language;
-        inputRedirect.setAttribute('data-wiki-key', key);
+        const inputRedirectTitle = extensionAPI.i18n.getMessage('settingsRedirectFor', [sites[i].origins_label, sites[i].destination]);
+        let inputRedirect = createRadioButton(site, inputRedirectTitle, 'toggleRedirect');
 
         // Create radio for disabling action on search engines:
         let labelSearchEngineDisabled = document.createElement("label");
-        let inputSearchEngineDisabled = document.createElement("input");
-        inputSearchEngineDisabled.classList = 'toggleSearchEngineDisabled';
-        inputSearchEngineDisabled.type = "radio";
-        inputSearchEngineDisabled.name = key + '-search-engine-action';
-        inputSearchEngineDisabled.title = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
-        inputSearchEngineDisabled.lang = sites[i].language;
-        inputSearchEngineDisabled.setAttribute('data-wiki-key', key);
+        const inputSearchEngineDisabledTitle = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
+        let inputSearchEngineDisabled = createRadioButton(site, inputSearchEngineDisabledTitle, 'toggleSearchEngineDisabled');
 
         // Create radio for replacing results on search engines:
         let labelSearchEngineReplace = document.createElement("label");
-        let inputSearchEngineReplace = document.createElement("input");
-        inputSearchEngineReplace.classList = 'toggleSearchEngineReplace';
-        inputSearchEngineReplace.type = "radio";
-        inputSearchEngineReplace.name = key + '-search-engine-action';
-        inputSearchEngineReplace.title = extensionAPI.i18n.getMessage('settingsReplaceFor', [sites[i].origins_label, sites[i].destination]);
-        inputSearchEngineReplace.lang = sites[i].language;
-        inputSearchEngineReplace.setAttribute('data-wiki-key', key);
+        const inputSearchEngineReplaceTitle = extensionAPI.i18n.getMessage('settingsReplaceFor', [sites[i].origins_label, sites[i].destination]);
+        let inputSearchEngineReplace = createRadioButton(site, inputSearchEngineReplaceTitle, 'toggleSearchEngineReplace');
 
         // Create radio for hiding results on search engines:
         let labelSearchEngineHide = document.createElement("label");
-        let inputSearchEngineHide = document.createElement("input");
-        inputSearchEngineHide.classList = 'toggleSearchEngineHide';
-        inputSearchEngineHide.type = "radio";
-        inputSearchEngineHide.name = key + '-search-engine-action';
-        inputSearchEngineHide.title = extensionAPI.i18n.getMessage('settingsHideFor', [sites[i].origins_label]);
-        inputSearchEngineHide.lang = sites[i].language;
-        inputSearchEngineHide.setAttribute('data-wiki-key', key);
+        const inputSearchEngineHideTitle = extensionAPI.i18n.getMessage('settingsHideFor', [sites[i].origins_label]);
+        let inputSearchEngineHide = createRadioButton(site, inputSearchEngineHideTitle, 'toggleSearchEngineHide');
 
         // Set wiki radio buttons based on user's settings
-        const wikiAction = wikiSettings[key] ?? defaultWikiAction ?? 'alert';
+        const wikiAction = wikiSettings[site.id] ?? defaultWikiAction ?? 'alert';
         
         switch(wikiAction) {
           case 'disabled':
@@ -146,7 +130,7 @@ async function loadOptions(lang, textFilter = '') {
         }
 
         // Set search engine radio buttons based on user's settings
-        const searchEngineAction = searchEngineSettings[key] ?? defaultSearchAction ?? 'replace';
+        const searchEngineAction = searchEngineSettings[site.id] ?? defaultSearchAction ?? 'replace';
 
         switch(searchEngineAction) {
           case 'true':
@@ -160,124 +144,103 @@ async function loadOptions(lang, textFilter = '') {
           default:
             inputSearchEngineHide.checked = true;
         }
+        
+        async function addWikiSettingsListener(button, dataWikiKey) {
+          button.addEventListener('click', (input) => {
+            extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
+              let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
+              const key = input.target.getAttribute('data-wiki-key');
+              wikiSettings[key] = dataWikiKey;
+              extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+            });
+          });
+        }
+        
+        async function addSearchEngineSettingsListener(button, dataWikiKey) {
+          button.addEventListener('click', (input) => {
+            extensionAPI.storage.sync.get({ 'searchEngineSettings': {} }, async (response) => {
+              let searchEngineSettings = await commonFunctionDecompressJSON(response.searchEngineSettings);
+              const key = input.target.getAttribute('data-wiki-key');
+              searchEngineSettings[key] = dataWikiKey;
+              extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
+            });
+          });
+        }
 
         // Add listeners for when user clicks control:
-        inputDisabled.addEventListener('click', (input) => {
-          extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
-            let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
-            var key = input.target.getAttribute('data-wiki-key');
-            wikiSettings[key] = 'disabled';
-            extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
-          });
-        });
-        inputAlert.addEventListener('click', (input) => {
-          extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
-            let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
-            var key = input.target.getAttribute('data-wiki-key');
-            wikiSettings[key] = 'alert';
-            extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
-          });
-        });
-        inputRedirect.addEventListener('click', (input) => {
-          extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
-            let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
-            var key = input.target.getAttribute('data-wiki-key');
-            wikiSettings[key] = 'redirect';
-            extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
-          });
-        });
-        inputSearchEngineDisabled.addEventListener('click', (input) => {
-          extensionAPI.storage.sync.get({ 'searchEngineSettings': {} }, async (response) => {
-            let searchEngineSettings = await commonFunctionDecompressJSON(response.searchEngineSettings);
-            var key = input.target.getAttribute('data-wiki-key');
-            searchEngineSettings[key] = 'disabled';
-            extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-          });
-        });
-        inputSearchEngineReplace.addEventListener('click', (input) => {
-          extensionAPI.storage.sync.get({ 'searchEngineSettings': {} }, async (response) => {
-            let searchEngineSettings = await commonFunctionDecompressJSON(response.searchEngineSettings);
-            var key = input.target.getAttribute('data-wiki-key');
-            searchEngineSettings[key] = 'replace';
-            extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-          });
-        });
-        inputSearchEngineHide.addEventListener('click', (input) => {
-          extensionAPI.storage.sync.get({ 'searchEngineSettings': {} }, async (response) => {
-            let searchEngineSettings = await commonFunctionDecompressJSON(response.searchEngineSettings);
-            var key = input.target.getAttribute('data-wiki-key');
-            searchEngineSettings[key] = 'hide';
-            extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-          });
-        });
+        addWikiSettingsListener(inputDisabled, 'disabled');
+        addWikiSettingsListener(inputAlert, 'alert');
+        addWikiSettingsListener(inputRedirect, 'click');
+
+        addSearchEngineSettingsListener(inputSearchEngineDisabled, 'disabled');
+        addSearchEngineSettingsListener(inputSearchEngineReplace, 'replace');
+        addSearchEngineSettingsListener(inputSearchEngineHide, 'hide');
+
+        function outputRadioButton(button, label, textContent) {
+          label.appendChild(button);
+
+          let buttonText = document.createElement('span');
+          buttonText.classList.add('visuallyHidden');
+          buttonText.textContent = textContent;
+          label.appendChild(buttonText);
+        }
 
         // Output wiki disable radio button:
-        let inputDisabledText = document.createElement('span');
-        inputDisabledText.classList.add('visuallyHidden');
-        inputDisabledText.textContent = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
-        labelDisabled.appendChild(inputDisabled);
-        labelDisabled.appendChild(inputDisabledText);
+        const inputDisabledTextContent = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
+        outputRadioButton(inputDisabled, labelDisabled, inputDisabledTextContent);
 
         // Output wiki alert radio button:
-        let inputAlertText = document.createElement('span');
-        inputAlertText.classList.add('visuallyHidden');
-        inputAlertText.textContent = extensionAPI.i18n.getMessage('settingsAlertFor', [sites[i].origins_label, sites[i].destination]);
-        labelAlert.appendChild(inputAlert);
-        labelAlert.appendChild(inputAlertText);
+        const inputAlertTextContent = extensionAPI.i18n.getMessage('settingsAlertFor', [sites[i].origins_label, sites[i].destination]);
+        outputRadioButton(inputAlert, labelAlert, inputAlertTextContent);
 
         // Output wiki redirect radio button:
-        let inputRedirectText = document.createElement('span');
-        inputRedirectText.classList.add('visuallyHidden');
-        inputRedirectText.textContent = extensionAPI.i18n.getMessage('settingsRedirectFor', [sites[i].origins_label, sites[i].destination]);
-        labelRedirect.appendChild(inputRedirect);
-        labelRedirect.appendChild(inputRedirectText);
+        const inputRedirectTextContent = extensionAPI.i18n.getMessage('settingsRedirectFor', [sites[i].origins_label, sites[i].destination]);
+        outputRadioButton(inputRedirect, labelRedirect, inputRedirectTextContent);
 
         // Output search engine disable radio button:
-        let inputSearchEngineDisabledText = document.createElement('span');
-        inputSearchEngineDisabledText.classList.add('visuallyHidden');
-        inputSearchEngineDisabledText.textContent = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
-        labelSearchEngineDisabled.appendChild(inputSearchEngineDisabled);
-        labelSearchEngineDisabled.appendChild(inputSearchEngineDisabledText);
+        const inputSearchEngineDisabledTextContent = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
+        outputRadioButton(inputSearchEngineDisabled, labelSearchEngineDisabled, inputSearchEngineDisabledTextContent);
 
         // Output search engine replace radio button:
-        let inputSearchEngineReplaceText = document.createElement('span');
-        inputSearchEngineReplaceText.classList.add('visuallyHidden');
-        inputSearchEngineReplaceText.textContent = extensionAPI.i18n.getMessage('settingsReplaceFor', [sites[i].origins_label, sites[i].destination]);
-        labelSearchEngineReplace.appendChild(inputSearchEngineReplace);
-        labelSearchEngineReplace.appendChild(inputSearchEngineReplaceText);
+        const inputSearchEngineReplaceTextContent = extensionAPI.i18n.getMessage('settingsReplaceFor', [sites[i].origins_label, sites[i].destination]);
+        outputRadioButton(inputSearchEngineReplace, labelSearchEngineReplace, inputSearchEngineReplaceTextContent);
 
         // Output search engine hide radio button:
-        let inputSearchEngineHideText = document.createElement('span');
-        inputSearchEngineHideText.classList.add('visuallyHidden');
-        inputSearchEngineHideText.textContent = extensionAPI.i18n.getMessage('settingsHideFor', [sites[i].origins_label]);
-        labelSearchEngineHide.appendChild(inputSearchEngineHide);
-        labelSearchEngineHide.appendChild(inputSearchEngineHideText);
+        const inputSearchEngineHideTextContent = extensionAPI.i18n.getMessage('settingsHideFor', [sites[i].origins_label]);
+        outputRadioButton(inputSearchEngineHide, labelSearchEngineHide, inputSearchEngineHideTextContent);
 
         // Output wiki info:
-        let wikiInfo = document.createElement('span');
+        const destinationSiteURL = `https://${site.destination_base_url}`;
+        const visitDestinationText = `Visit ${site.destination}`;
+
         let iconLink = document.createElement("a");
-        iconLink.href = 'https://' + sites[i].destination_base_url;
-        iconLink.title = 'Visit ' + sites[i].destination;
+        iconLink.href = destinationSiteURL;
+        iconLink.title = visitDestinationText;
         iconLink.target = '_blank';
+
         let icon = document.createElement("img");
-        icon.src = '../../favicons/' + sites[i].language.toLowerCase() + '/' + sites[i].destination_icon;
-        icon.alt = 'Visit ' + sites[i].destination;
+        icon.src = `../../favicons/${site.language.toLowerCase()}/${site.destination_icon}`;
+        icon.alt = visitDestinationText;
         icon.width = '16';
         iconLink.appendChild(icon);
+
+        let wikiInfo = document.createElement('span');
         wikiInfo.appendChild(iconLink);
         if (lang === 'ALL') {
           const languageSpan = document.createElement('span');
           languageSpan.classList.add('text-sm');
-          languageSpan.innerText = ' [' + sites[i].language + '] ';
+          languageSpan.innerText = ` [${site.language}] `;
           wikiInfo.appendChild(languageSpan);
         }
+
         let wikiLink = document.createElement("a");
-        wikiLink.href = 'https://' + sites[i].destination_base_url;
-        wikiLink.title = 'Visit ' + sites[i].destination;
+        wikiLink.href = destinationSiteURL;
+        wikiLink.title = visitDestinationText;
         wikiLink.target = '_blank';
-        wikiLink.appendChild(document.createTextNode(sites[i].destination));
+        wikiLink.appendChild(document.createTextNode(site.destination));
         wikiInfo.appendChild(wikiLink);
         wikiInfo.appendChild(document.createTextNode(extensionAPI.i18n.getMessage('settingsWikiFrom', [sites[i].origins_label])));
+
         let siteContainer = document.createElement("div");
         siteContainer.classList.add('site-container')
 
@@ -290,71 +253,44 @@ async function loadOptions(lang, textFilter = '') {
         inputsContainer.appendChild(labelSearchEngineReplace);
         inputsContainer.appendChild(labelSearchEngineHide);
         inputsContainer.classList = 'inputsContainer';
+
         siteContainer.appendChild(wikiInfo);
         siteContainer.appendChild(inputsContainer);
         toggleContainer.appendChild(siteContainer);
       }
 
+      async function addGlobalButtonEventListeners_Wiki(globalButtonID, actionValue, targetClass) {
+        const setAllRedirect = document.getElementById(globalButtonID);
+        setAllRedirect.addEventListener('click', async () => {
+          const toggles = document.querySelectorAll(`#toggles input.${targetClass}`);
+          for (let i = 0; i < toggles.length; i++) {
+            toggles[i].checked = true;
+            wikiSettings[toggles[i].getAttribute('data-wiki-key')] = actionValue;
+          }
+          extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+        });
+      }
+
+      async function addGlobalButtonEventListeners_SearchEngine(globalButtonID, actionValue, targetClass) {
+        const setAllRedirect = document.getElementById(globalButtonID);
+        setAllRedirect.addEventListener('click', async () => {
+          const toggles = document.querySelectorAll(`#toggles input.${targetClass}`);
+          for (let i = 0; i < toggles.length; i++) {
+            toggles[i].checked = true;
+            searchEngineSettings[toggles[i].getAttribute('data-wiki-key')] = actionValue;
+          }
+          extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
+        });
+      }
+
       // Add "select all" button event listeners:
-      const setAllRedirect = document.getElementById('setAllRedirect');
-      setAllRedirect.addEventListener('click', async () => {
-        const toggles = document.querySelectorAll('#toggles input.toggleRedirect');
-        for (var i = 0; i < toggles.length; i++) {
-          toggles[i].checked = true;
-          wikiSettings[toggles[i].getAttribute('data-wiki-key')] = 'redirect';
-        }
-        extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
-      });
+      addGlobalButtonEventListeners_Wiki('setAllRedirect', 'redirect', 'toggleRedirect');
+      addGlobalButtonEventListeners_Wiki('setAllAlert', 'alert', 'toggleAlert');
+      addGlobalButtonEventListeners_Wiki('setAllDisabled', 'disabled', 'toggleDisable');
 
-      const setAllAlert = document.getElementById('setAllAlert');
-      setAllAlert.addEventListener('click', async () => {
-        const toggles = document.querySelectorAll('#toggles input.toggleAlert');
-        for (var i = 0; i < toggles.length; i++) {
-          toggles[i].checked = true;
-          wikiSettings[toggles[i].getAttribute('data-wiki-key')] = 'alert';
-        }
-        extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
-      });
-
-      const setAllDisabled = document.getElementById('setAllDisabled');
-      setAllDisabled.addEventListener('click', async () => {
-        const toggles = document.querySelectorAll('#toggles input.toggleDisable');
-        for (var i = 0; i < toggles.length; i++) {
-          toggles[i].checked = true;
-          wikiSettings[toggles[i].getAttribute('data-wiki-key')] = 'disabled';
-        }
-        extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
-      });
-
-      const setAllSearchEngineDisabled = document.getElementById('setAllSearchEngineDisabled');
-      setAllSearchEngineDisabled.addEventListener('click', async () => {
-        const toggles = document.querySelectorAll('#toggles input.toggleSearchEngineDisabled');
-        for (var i = 0; i < toggles.length; i++) {
-          toggles[i].checked = true;
-          searchEngineSettings[toggles[i].getAttribute('data-wiki-key')] = 'disabled';
-        }
-        extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-      });
-
-      const setAllSearchEngineHide = document.getElementById('setAllSearchEngineHide');
-      setAllSearchEngineHide.addEventListener('click', async () => {
-        const toggles = document.querySelectorAll('#toggles input.toggleSearchEngineHide');
-        for (var i = 0; i < toggles.length; i++) {
-          toggles[i].checked = true;
-          searchEngineSettings[toggles[i].getAttribute('data-wiki-key')] = 'hide';
-        }
-        extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-      });
-
-      const setAllSearchEngineReplace = document.getElementById('setAllSearchEngineReplace');
-      setAllSearchEngineReplace.addEventListener('click', async () => {
-        const toggles = document.querySelectorAll('#toggles input.toggleSearchEngineReplace');
-        for (var i = 0; i < toggles.length; i++) {
-          toggles[i].checked = true;
-          searchEngineSettings[toggles[i].getAttribute('data-wiki-key')] = 'replace';
-        }
-        extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-      });
+      addGlobalButtonEventListeners_SearchEngine('setAllSearchEngineDisabled', 'disabled', 'toggleSearchEngineDisabled');
+      addGlobalButtonEventListeners_SearchEngine('setAllSearchEngineHide', 'hide', 'toggleSearchEngineHide');
+      addGlobalButtonEventListeners_SearchEngine('setAllSearchEngineReplace', 'replace', 'toggleSearchEngineReplace');
     });
   });
 }

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -88,17 +88,17 @@ async function loadOptions(lang, textFilter = '') {
         // Create radio for disabling action on wiki:
         let labelDisabled = document.createElement("label");
         const inputDisabledTitle = extensionAPI.i18n.getMessage('settingsDisableFor', [sites[i].origins_label]);
-        let inputDisabled = createRadioButton(site, inputDisabledTitle, 'toggleDisable');
+        let inputDisabled = createRadioButton(site, inputDisabledTitle, 'toggleWikiDisabled');
 
         // Create radio for inserting banner on wiki:
         let labelAlert = document.createElement("label");
         const inputAlertTitle = extensionAPI.i18n.getMessage('settingsAlertFor', [sites[i].origins_label, sites[i].destination]);
-        let inputAlert = createRadioButton(site, inputAlertTitle, 'toggleAlert');
+        let inputAlert = createRadioButton(site, inputAlertTitle, 'toggleWikiAlert');
 
         // Create radio for redirecting wiki:
         let labelRedirect = document.createElement("label");
         const inputRedirectTitle = extensionAPI.i18n.getMessage('settingsRedirectFor', [sites[i].origins_label, sites[i].destination]);
-        let inputRedirect = createRadioButton(site, inputRedirectTitle, 'toggleRedirect');
+        let inputRedirect = createRadioButton(site, inputRedirectTitle, 'toggleWikiRedirect');
 
         // Create radio for disabling action on search engines:
         let labelSearchEngineDisabled = document.createElement("label");
@@ -284,9 +284,9 @@ async function loadOptions(lang, textFilter = '') {
       }
 
       // Add "select all" button event listeners:
-      addGlobalButtonEventListeners_Wiki('setAllRedirect', 'redirect', 'toggleRedirect');
-      addGlobalButtonEventListeners_Wiki('setAllAlert', 'alert', 'toggleAlert');
-      addGlobalButtonEventListeners_Wiki('setAllDisabled', 'disabled', 'toggleDisable');
+      addGlobalButtonEventListeners_Wiki('setAllRedirect', 'redirect', 'toggleWikiRedirect');
+      addGlobalButtonEventListeners_Wiki('setAllAlert', 'alert', 'toggleWikiAlert');
+      addGlobalButtonEventListeners_Wiki('setAllDisabled', 'disabled', 'toggleWikiDisabled');
 
       addGlobalButtonEventListeners_SearchEngine('setAllSearchEngineDisabled', 'disabled', 'toggleSearchEngineDisabled');
       addGlobalButtonEventListeners_SearchEngine('setAllSearchEngineHide', 'hide', 'toggleSearchEngineHide');

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -4,7 +4,14 @@ let sites = [];
 // Used when switching languages
 function resetOptions() {
   const toggleTableBody = document.getElementById('togglesBody');
-  toggleTableBody.innerHTML = "";
+
+   // Need to create a copy first, because the children change while iterating
+  const toggleTableRows = [...toggleTableBody.children];
+  for(el of toggleTableRows) {
+    if(el.classList?.contains('site-container')) {
+      el.remove();
+    }
+  }
 
   // Clone "select all" buttons to reset listeners
   document.getElementById('setAllWikiDisabled').cloneNode(true);

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -3,8 +3,8 @@ let sites = [];
 // Clear wiki toggles
 // Used when switching languages
 function resetOptions() {
-  const toggleContainer = document.getElementById('toggles');
-  toggleContainer.textContent = "";
+  const toggleTableBody = document.getElementById('togglesBody');
+  toggleTableBody.innerHTML = "";
 
   // Clone "select all" buttons to reset listeners
   document.getElementById('setAllWikiDisabled').cloneNode(true);
@@ -115,7 +115,7 @@ async function loadOptions(lang, textFilter = '') {
       resetOptions();
 
       // Populate individual wiki settings:
-      const toggleContainer = document.getElementById('toggles');
+      const toggleTableBody = document.getElementById('togglesBody');
       for (let i = 0; i < sites.length; i++) {
         const redirectEntry = sites[i];
 
@@ -161,53 +161,62 @@ async function loadOptions(lang, textFilter = '') {
         const destinationSiteURL = `https://${redirectEntry.destination_base_url}`;
         const visitDestinationText = `Visit ${redirectEntry.destination}`;
 
-        let icon = document.createElement("img");
+        // Create row container
+        const siteRow = document.createElement("tr");
+        siteRow.classList.add('site-container');
+
+        // Create icon for the destination wiki
+        const icon = document.createElement("img");
         icon.src = `../../favicons/${redirectEntry.language.toLowerCase()}/${redirectEntry.destination_icon}`;
         icon.alt = visitDestinationText;
-        icon.width = '16';
+        icon.style.width = '16px';
         
-        let iconLink = document.createElement("a");
-        iconLink.href = destinationSiteURL;
-        iconLink.title = visitDestinationText;
-        iconLink.target = '_blank';
-        iconLink.appendChild(icon);
+        const linkedIcon = document.createElement("a");
+        linkedIcon.href = destinationSiteURL;
+        linkedIcon.title = visitDestinationText;
+        linkedIcon.target = '_blank';
+        linkedIcon.appendChild(icon);
 
-        let wikiLink = document.createElement("a");
+        const iconCell = document.createElement("td");
+        iconCell.appendChild(linkedIcon);
+        siteRow.appendChild(iconCell);
+
+        // Create text description of the redirect
+        const wikiLink = document.createElement("a");
         wikiLink.href = destinationSiteURL;
         wikiLink.title = visitDestinationText;
         wikiLink.target = '_blank';
         wikiLink.appendChild(document.createTextNode(redirectEntry.destination));
 
-        let wikiInfo = document.createElement('span');
-        wikiInfo.appendChild(iconLink);
+        const wikiInfo = document.createElement('td');
         if (lang === 'ALL') {
           const languageSpan = document.createElement('span');
           languageSpan.classList.add('text-sm');
           languageSpan.innerText = ` [${redirectEntry.language}] `;
           wikiInfo.appendChild(languageSpan);
         }
+        wikiInfo.classList.add('wiki-description');
         wikiInfo.appendChild(wikiLink);
         wikiInfo.appendChild(document.createTextNode(extensionAPI.i18n.getMessage('settingsWikiFrom', [sites[i].origins_label])));
 
-        // Create inputs container:
-        let inputsContainer = document.createElement('div');
-        inputsContainer.classList = 'inputsContainer';
+        siteRow.appendChild(wikiInfo);
 
         // Wrap each of the buttons and add them to the container
-        const radioButtonArray = [inputWikiDisabled, inputWikiAlert, inputWikiRedirect, inputSearchEngineDisabled, inputSearchEngineReplace, inputSearchEngineHide];
-        for(radioButton of radioButtonArray) {
-          const buttonWrapper = document.createElement("div");
-          buttonWrapper.appendChild(radioButton);
-          inputsContainer.appendChild(buttonWrapper);
+        const rowCells = [
+          inputWikiDisabled, 
+          inputWikiAlert, 
+          inputWikiRedirect, 
+          inputSearchEngineDisabled, 
+          inputSearchEngineReplace, 
+          inputSearchEngineHide
+        ];
+        for(cellContent of rowCells) {
+          const cell = document.createElement("td");
+          cell.appendChild(cellContent);
+          siteRow.appendChild(cell);
         }
 
-        // Create row container
-        const siteContainer = document.createElement("div");
-        siteContainer.classList.add('site-container')
-
-        siteContainer.appendChild(wikiInfo);
-        siteContainer.appendChild(inputsContainer);
-        toggleContainer.appendChild(siteContainer);
+        toggleTableBody.appendChild(siteRow);
       }
 
       // Add "select all" button event listeners:
@@ -525,19 +534,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Get and display stat counts
   extensionAPI.storage.sync.get({ 'countAlerts': 0 }, (item) => {
-    var key = Object.keys(item)[0];
+    const key = Object.keys(item)[0];
     document.getElementById('countAlerts').textContent = item[key];
   });
   extensionAPI.storage.sync.get({ 'countRedirects': 0 }, (item) => {
-    var key = Object.keys(item)[0];
+    const key = Object.keys(item)[0];
     document.getElementById('countRedirects').textContent = item[key];
   });
   extensionAPI.storage.sync.get({ 'countSearchFilters': 0 }, (item) => {
-    var key = Object.keys(item)[0];
+    const key = Object.keys(item)[0];
     document.getElementById('countSearchFilters').textContent = item[key];
   });
   extensionAPI.storage.sync.get({ 'countBreezeWiki': 0 }, (item) => {
-    var key = Object.keys(item)[0];
+    const key = Object.keys(item)[0];
     document.getElementById('countBreezeWiki').textContent = item[key];
   });
 });

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -1,4 +1,4 @@
-var LANGS = ["DE", "EN", "ES", "FI", "FR", "HU", "IT", "JA", "LZH", "KO", "PL", "PT", "RU", "SV", "TH", "TOK", "UK", "ZH"];
+var LANGS = ["DE", "EN", "ES", "FI", "FR", "HU", "IT", "JA", "KO", "LZH", "PL", "PT", "RU", "SV", "TH", "TOK", "UK", "ZH"];
 var BASE64REGEX = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 const extensionAPI = typeof browser === "undefined" ? chrome : browser;
 

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -1,4 +1,4 @@
-﻿var LANGS = ["DE", "EN", "ES", "FI", "FR", "HU", "IT", "JA", "LZH", "KO", "PL", "PT", "RU", "SV", "TH", "TOK", "UK", "ZH"];
+var LANGS = ["DE", "EN", "ES", "FI", "FR", "HU", "IT", "JA", "LZH", "KO", "PL", "PT", "RU", "SV", "TH", "TOK", "UK", "ZH"];
 var BASE64REGEX = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 const extensionAPI = typeof browser === "undefined" ? chrome : browser;
 
@@ -11,6 +11,25 @@ function b64decode(str) {
     bytes[i] = binary_string.charCodeAt(i);
   }
   return bytes;
+}
+
+/**
+ * Joins an array of strings as a camelCase string
+ * @param {string[]} stringArray
+ * @returns {string}
+ */
+function camelCaseJoin(stringArray) {
+  let outputString = "";
+  for(let i = 0; i < stringArray.length; i++)
+  {
+    const stringEntry = stringArray[i];
+    if (i == 0) {
+      outputString += stringEntry;
+    } else {
+      outputString += stringEntry.charAt(0).toUpperCase() + stringEntry.slice(1);
+    }
+  }
+  return outputString;
 }
 
 /** @param {string} value */


### PR DESCRIPTION
The script for the settings page included a large amount of duplicated code, so I refactored it to put that reused code in functions instead. I also refactored other code, such as massively simplifying the function that converts the user's settings to checked radio buttons.

Additionally, I refactored the "Individual wiki settings" table to actually be built using a table, instead of a structure that only appears to be a table.

I also made various other minor adjustments to the Settings page:
- Adjust the formatting of the "icon legend" box to be consistent with the other boxes on the page.
- Replaced the emoji 🍃 instead of the Tibetan character ༄ to represent BreezeWiki. The Tibetan character was rendering much smaller than the emoji in the other boxes. But regardless, it's better not to use characters non-semantically.
- Add a border around the "individual wiki settings" table, for consistency with the other boxes on the page.