### PR TITLE
Adjust search engine re-ordering logic

### DIFF
--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -339,9 +339,11 @@ function getResultContainer(searchEngine, searchResult) {
       /** @type {HTMLElement | null} */
       const closestJsController = searchResult.closest('div[jscontroller]');
       /** @type {HTMLElement | null} */
+      const closestJsName = searchResult.closest('div[jsname]');
+      /** @type {HTMLElement | null} */
       const closestDataDiv = searchResult.closest('div[data-hveid].g') || searchResult.closest('div[data-hveid]');
       // For Google search results, get the parentNode of the result container as that tends to be more reliable:
-      searchResultContainer = findClosestElement(searchResult, [closestJsController, closestDataDiv])?.parentElement;
+      searchResultContainer = findClosestElement(searchResult, [closestJsController, closestJsName, closestDataDiv])?.parentElement;
       break;
     case 'bing':
       searchResultContainer = searchResult.closest('li.b_algo');
@@ -560,6 +562,8 @@ function filterAnchors(newAnchors) {
     case 'google': {
       // Query Google results and rewrite HREFs when Google uses middleman links (i.e. google.com/url?q=)
       let searchResults = newAnchors.filter(e => e.matches("div[data-hveid] a:first-of-type:not([role='button']):not([target='_self'])"));
+      
+      // Filter out search results that are within other search results
       searchResults = searchResults.filter(
         e =>
           !e.closest(

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -510,7 +510,7 @@ async function filterSearchResults(searchResults) {
                 anchor: searchResult,
               };
 
-              if ((storage.reorderResults ?? 'on') == 'on' && searchResultContainer && processedCache[0]) {
+              if ((storage.reorderResults ?? 'on') == 'on' && searchResultContainer && processedCache[0] && processedCache[0].isNonIndie && processedCache[0].container) {
                 console.debug('Indie Wiki Buddy: Reordering search result:', searchResultLink);
                 processedCache[0].container.insertAdjacentElement('beforebegin', searchResultContainer);
                 processedCache.push(cacheInfo);


### PR DESCRIPTION
For search engine result re-ordering:
* Previously, re-ordering would move all indie results above the first non-indie result. With recent PR #776, re-ordering logic was changed to *swap* the first indie result with the first non-indie result. This works, but was limited to just swapping and hiding one result. We've re-implemented the previous solution, so that all indie results are moved above the first non-indie result. Swapping is still used but is not restricted to just one result.
* Previously, non-indie results with article titles matching an indie wiki result would be hidden regardless of whether re-ordering was enabled. This PR adds a check for re-ordering to be enabled before hiding.

Other:
* Adjust top-mount CSS query for Firefox Android to use `'#main > div:nth-of-type(2)'` CSS query, instead of searching for the `data-hveid` attribute. This helps account for "special" results that appear at the top but don't have a `data-hveid` attribute, like featured snippets.