### PR TITLE
the dota2 game wiki is merging with the dota2 esports wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -2050,8 +2050,8 @@
     "destination_platform": "mediawiki",
     "destination_icon": "liquipediadota2wiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/dota2game/index.php",
-    "destination_content_path": "/dota2game/"
+    "destination_search_path": "/dota2/index.php",
+    "destination_content_path": "/dota2/"
   },
   {
     "id": "en-dotflow",


### PR DESCRIPTION
This is a followup to #659, the dota2 game wiki hosted by liquidpedia (former fandom wiki) merged with the dota2 esports wiki hosted by liquipedia, see https://github.com/KevinPayravi/indie-wiki-buddy/pull/659#issuecomment-2279558693.

This changes the path from `dota2game` to `dota`.

Thank you.

cc @irismus