### PR TITLE
Update Space Station 14's wiki domain

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -8036,7 +8036,7 @@
       }
     ],
     "destination": "Space Station 14 Wiki",
-    "destination_base_url": "wiki.spacestation14.io",
+    "destination_base_url": "wiki.spacestation14.com",
     "destination_platform": "mediawiki",
     "destination_icon": "ss14.png",
     "destination_main_page": "Main_Page",


### PR DESCRIPTION
Space Station 14 recently changed their domain from [wiki.spacestation14.io](https://wiki.spacestation14.io) to [wiki.spacestation14.com](https://wiki.spacestation14.io). While the .io domain currently redirects, it is better to use the new domain directly.