### PR TITLE
Removing the now-defunct Minetest/Luanti Wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -6169,28 +6169,6 @@
     "destination_host": "wiki.gg"
   },
   {
-    "id": "en-minetest",
-    "origins_label": "Minetest Fandom Wiki",
-    "origins": [
-      {
-        "origin": "Minetest Fandom Wiki",
-        "origin_base_url": "minetest.fandom.com",
-        "origin_content_path": "/wiki/",
-        "origin_main_page": "Minetest_Wiki"
-      }
-    ],
-    "destination": "Minetest Wiki",
-    "destination_base_url": "wiki.minetest.net",
-    "destination_platform": "mediawiki",
-    "destination_icon": "minetestwiki.png",
-    "destination_main_page": "Main_Page",
-    "destination_search_path": "/index.php",
-    "destination_content_path": "/",
-    "tags": [
-      "official"
-    ]
-  },
-  {
     "id": "en-minicraft",
     "origins_label": "Minicraft Fandom Wiki",
     "origins": [


### PR DESCRIPTION
The Minetest Wiki was migrated to a documentation site that no longer uses MediaWiki and uses a website builder called [Hugo](https://gohugo.io/).⁽[¹](https://docs.luanti.org/about-this-site/)⁾ [wiki.minetest.net](https://wiki.minetest.net) now redirect to [docs.luanti.org](https://docs.luanti.org/)
![image](https://github.com/user-attachments/assets/e310e392-42b4-445f-b2d7-52222ed9b419)

Plus, the topic (in this case the voxels video game Minetest) rebranded to "Luanti" in October 2024.⁽[²](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name/)⁾

I think this entry needs to be removed. Anyways, thank you for reading!
- Pretz(tea)

Sources
[1 - Luanti Documentation | _About This Site_](https://docs.luanti.org/about-this-site/)
[2 - Luanti Blog | _Introducing Our New Name_](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name/)