### PR TITLE
Repair invalid JSON syntax

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -8877,24 +8877,24 @@
     "destination_content_path": "/wiki/"
   },
   {
-  "id": "en-skylanders",
-  "origins_label": "Skylanders Fandom Wiki",
-  "origins": [
-    {
-      "origin": "Skylanders Fandom Wiki",
-      "origin_base_url": "skylanders.fandom.com",
-      "origin_content_path": "/wiki/",
-      "origin_main_page": "Main_Page"
-    }
-  ],
-  "destination": "Skylanders Wiki",
-  "destination_base_url": "skylanderswiki.com",
-  "destination_platform": "mediawiki",
-  "destination_icon": "skylanders.png",
-  "destination_main_page": "Main_Page",
-  "destination_search_path": "/index.php",
-  "destination_content_path": "/wiki/"
-}
+    "id": "en-skylanders",
+    "origins_label": "Skylanders Fandom Wiki",
+    "origins": [
+      {
+        "origin": "Skylanders Fandom Wiki",
+        "origin_base_url": "skylanders.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Main_Page"
+      }
+    ],
+    "destination": "Skylanders Wiki",
+    "destination_base_url": "skylanderswiki.com",
+    "destination_platform": "mediawiki",
+    "destination_icon": "skylanders.png",
+    "destination_main_page": "Main_Page",
+    "destination_search_path": "/index.php",
+    "destination_content_path": "/wiki/"
+  },
   {
     "id": "en-slarpg",
     "origins_label": "Super Lesbian Animal RPG Fandom Wiki",


### PR DESCRIPTION
sitesEN.json had invalid JSON syntax (it was missing a comma), which was causing the extension to fail to load any site data.

Also adjusting the indentation on the new Skylanders entry (although that wasn't the issue).