### PR TITLE
Repair support for Yandex

### DIFF
--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -64,7 +64,7 @@ function removeSubstringIfAtEnd(str, sub) {
  * @returns {string}
  */
 function getClosestBackgroundColor(element) {
-  let parent = element.parentElement;
+  let parent = element;
   while (parent) {
     const style = window.getComputedStyle(parent);
     const bgColor = style.backgroundColor;

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -415,7 +415,7 @@ function getResultContainer(searchEngine, searchResult) {
       searchResultContainer = searchResult.closest('div.result, div.w-gl__result');
       break;
     case 'yandex':
-      searchResultContainer = searchResult.closest('li[data-cid], .serp-item, .MMOrganicSnippet, .viewer-snippet');
+      searchResultContainer = searchResult.closest('#search-result > li, #search-result > div[data-yaet4], li[data-cid], .serp-item, .MMOrganicSnippet, .viewer-snippet');
       break;
     case 'yahoo':
       searchResultContainer = searchResult.closest('#web > ol > li div.itm .exp, #web > ol > li div.algo, #web > ol > li, section.algo');
@@ -726,7 +726,7 @@ function filterAnchors(newAnchors) {
       break;
     }
     case 'yandex': {
-      const searchResults = newAnchors.filter(e => e.matches('li[data-cid] a.link, li[data-cid] a.Link, .serp-item a.link, .serp-item a.Link, .MMOrganicSnippet a, .viewer-snippet a'));
+      const searchResults = newAnchors.filter(e => e.matches('li a.link, li a.Link, .OrganicTitle a.Link, .serp-item a.link, .serp-item a.Link, .MMOrganicSnippet a, .viewer-snippet a'));
       filterSearchResults(searchResults);
       break;
     }


### PR DESCRIPTION
IWB was not working on Yandex, presumably due to some change in how Yandex search pages are structured. I've updated the selectors to work on the current version of Yandex.com's desktop and mobile sites.

I've left the pre-existing Yandex selectors in-tact, since I don't know why they were added (potentially for one of the international Yandex variants like yandex.fr). Although I did check ya.ru at least, which does use the `.serp-item` class, but it would also be matched just as well by the `#search-result > li` selector I added, so it's possible many of those are redundant.

Additionally, I adjusted the background color detector to start looking for background colors on the search result element itself, rather than its parent. Since the IWB element is being inserted inside of the search result itself, it's important that the color align with that element if it has one. On Yandex.com, this was causing IWB to grab the background color of the background the search results are displayed on, which was causing a colored box around the IWB element.

Before the background fix:
<img width="712" height="198" alt="image" src="https://github.com/user-attachments/assets/e62dd712-7e10-4bab-afa8-b93225883614" />

After the background fix:
<img width="740" height="200" alt="image" src="https://github.com/user-attachments/assets/b5512640-fb5c-41a7-a851-fcb4961c0fdf" />
