### PR TITLE
Update Lain Wiki origin subdomain 

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -8781,7 +8781,7 @@
     "origins": [
       {
         "origin": "Serial Experiments Lain Fandom Wiki",
-        "origin_base_url": "sel.fandom.com",
+        "origin_base_url": "lain.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Serial_Experiments_Lain_Wiki"
       }


### PR DESCRIPTION
Resolves #1230 
From the linked issue, it seems like the sub-domain of the source wiki changed, and IWB does not recognise it anymore
Redirection of the original URL still works, but the banner no longer appears on the source wiki

I'm not sure if it would be better to keep the original url in the data file, or if would be better to just replace the URL (like is being done in this pr)