### PR TITLE
Update SCP Secret Laboratory Wiki URL

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -8663,7 +8663,7 @@
     "origins": [
       {
         "origin": "SCP: Secret Laboratory Fandom Wiki",
-        "origin_base_url": "scp-secret-laboratory-official.fandom.com",
+        "origin_base_url": "scp-secret-laboratory.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "SCP:_Secret_Laboratory_Official_Wiki"
       }


### PR DESCRIPTION
Resolves #1236 
Similar to #1233, the URL of the base wiki changed and it is not recognised by the extension. The url used to be `scp-secret-laboratory-official.fandom.com`, it now redirects to `scp-secret-laboratory.fandom.com`