### PR TITLE
2XKO Wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -86,7 +86,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "2xkowiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/en-us//index.php",
+    "destination_search_path": "/en-us/",
     "destination_content_path": "/en-us/",
     "tags": [
       "official"


### PR DESCRIPTION
Updated destination_base_url and paths for 2XKO Wiki. The 2XKO Wiki received an official wiki from Weird Gloop and Riot Games, and the 2XKO Wiki from StrategyWiki is considering to sunset.

Old wiki: https://2xko.wiki/w/Main_Page
New wiki: https://wiki.play2xko.com/en-us