### PR TITLE
Update JBC Studios Wiki to Item Asylum Wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -5507,11 +5507,11 @@
         "origin_main_page": "Item_Asylum_Wiki"
       }
     ],
-    "destination": "JBC Studios Wiki",
-    "destination_base_url": "jbcstudios.miraheze.org",
+    "destination": "Item Asylum Wiki",
+    "destination_base_url": "itemasylum.miraheze.org",
     "destination_platform": "mediawiki",
     "destination_icon": "jbcstudioswiki.png",
-    "destination_main_page": "JBC_Studios_Wiki",
+    "destination_main_page": "Item_Asylum_Wiki",
     "destination_search_path": "/w/index.php",
     "destination_content_path": "/",
     "destination_host": "Miraheze",


### PR DESCRIPTION
Replacing any mention of "JBC Studios" (aside from icon) to "Item Asylum" as the wiki's subdomain has been moved to itemasylum.miraheze.org.

I would also like "jbcstudioswiki.png" to be replaced with this image, and to be named as "itemasylumwiki.png"

<img width="48" height="48" alt="itemasylumwiki" src="https://github.com/user-attachments/assets/bffc01e8-7ef4-46b1-b270-f4b0723d8494" />
