### PR TITLE
Add note about BreezeWiki rate limit errors to settings page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -320,8 +320,8 @@
     "message": "BreezeWiki host:",
     "description": "Select for a BreezeWiki host"
   },
-  "settingsBreezeWikiHostTrafficNote": {
-    "message": "Note that if a BreezeWiki host gets a lot of traffic, it is likely to hit a rate limit and show an error message. If you get frequent errors visiting BreezeWiki, try switching to a different host.",
+  "settingsBreezeWikiHostNote": {
+    "message": "If you get frequent errors visiting BreezeWiki, try switching to a different host. Indie Wiki Buddy is not responsible for BreezeWiki or its hosts.",
     "description": "A short text above the BreezeWiki host selection"
   },
   "settingsBreezeWikiCustomHost": {

--- a/css/settings.css
+++ b/css/settings.css
@@ -42,7 +42,7 @@ legend {
   gap: 1em;
 }
 
-#breezewikiHostTrafficNote {
+#breezewikiHostNote {
   margin-bottom: 8px;
 }
 

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -186,7 +186,7 @@
             </div>
           </div>
           <div id="breezewikiHost" class="settingToggle">
-            <div id="breezewikiHostTrafficNote" data-msg="settingsBreezeWikiHostTrafficNote"></div>
+            <div id="breezewikiHostNote" data-msg="settingsBreezeWikiHostNote"></div>
             <label>
               <span data-msg="settingsBreezeWikiHost"></span>
               <select name="breezewikiHost" id="breezewikiHostSelect"></select>


### PR DESCRIPTION
Fixes #1333 by adding the following note if BreezeWiki banner or redirect is enabled:

> Note that if a BreezeWiki host gets a lot of traffic, it is likely to hit a rate limit and show an error message. If you get frequent errors visiting BreezeWiki, try switching to a different host.

<img width="701" height="206" alt="image" src="https://github.com/user-attachments/assets/5a232f05-2fa3-4026-aed7-86d61ca0e12e" />