### PR TITLE
wikipesija.org moved to tok.wikipedia.org

### DIFF
--- a/data/sitesTOK.json
+++ b/data/sitesTOK.json
@@ -15,8 +15,7 @@
     "destination_platform": "mediawiki",
     "destination_icon": "wikipesija.png",
     "destination_main_page": "lipu_open",
-    "destination_search_path": "/index.php",
-    "destination_content_path": "/wiki/",
-    "destination_host": "Wikipedia"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/"
   }
 ]


### PR DESCRIPTION
Now `wikipesija.org` redirects to `tok.wikipedia.org`. 

I didn't change the icon file. We can use the [puzzle globe](https://commons.wikimedia.org/wiki/File:Wikipedia-logo-v2.svg) or the ["W" trademark](https://commons.wikimedia.org/wiki/File:Wikipedia%27s_W.svg).