### PR TITLE
Prevent banner link color being overridden

### DIFF
--- a/css/content-banners.css
+++ b/css/content-banners.css
@@ -1,60 +1,63 @@
 #indie-wiki-banner-container {
-    font-family: sans-serif;
-    width: 100%;
-    z-index: 2147483647;
-    position: sticky;
-    top: 0;
-    text-align: center;
-  }
-  .indie-wiki-banner {
-    background-color: #acdae2;
-    padding: 8px 10px;
-    font-size: 12px;
-  }
-  .indie-wiki-banner-exit {
-    position: absolute;
-    right: 8px;
-    top: 4px;
-    font-size: 20px;
-    color: #333;
-    cursor: pointer;
-  }
-  .indie-wiki-banner-controls {
-    padding-bottom: 5px;
-  }
-  .indie-wiki-banner-big-text {
-    font-size: 14px;
-    line-height: 24px;
-    margin-top: 5px;
-  }
-  .indie-wiki-banner-big-text .indie-wiki-banner-link{
-    font-size: 16px;
-  }
-  .indie-wiki-banner-link {
-    font-weight: 600;
-    color: #000080;
-    cursor: pointer;
-    padding: 0 10px;
-    display: block;
-    width: fit-content;
-    margin: 0 auto;
-  }
-  .indie-wiki-banner-link:hover {
-    text-decoration: underline;
-    color: #000080;
-  }
-  .indie-wiki-banner-link-small {
-    display: inline-block;
-    font-size: 12px;
-    min-width: 180px;
-  }
-  .indie-wiki-banner-disabled {
-    color: #333;
-    cursor: default;
-  }
-  .indie-wiki-banner-disabled:hover {
-    text-decoration: none;
-  }
-  .indie-wiki-banner-hidden {
-    display: none;
-  }
+  font-family: sans-serif;
+  width: 100%;
+  z-index: 2147483647;
+  position: sticky;
+  top: 0;
+  text-align: center;
+}
+.indie-wiki-banner {
+  background-color: #acdae2;
+  padding: 8px 10px;
+  font-size: 12px;
+}
+.indie-wiki-banner-exit {
+  position: absolute;
+  right: 8px;
+  top: 4px;
+  font-size: 20px;
+  color: #333;
+  cursor: pointer;
+}
+.indie-wiki-banner-controls {
+  padding-bottom: 5px;
+}
+.indie-wiki-banner-big-text {
+  font-size: 14px;
+  line-height: 24px;
+  margin-top: 5px;
+}
+.indie-wiki-banner-big-text .indie-wiki-banner-link {
+  font-size: 16px;
+}
+.indie-wiki-banner-link {
+  font-weight: 600;
+  color: #000080;
+  cursor: pointer;
+  padding: 0 10px;
+  display: block;
+  width: fit-content;
+  margin: 0 auto;
+}
+.indie-wiki-banner-link:hover {
+  text-decoration: underline;
+  color: #000080;
+}
+.indie-wiki-banner-link:focus {
+  color: #000080;
+}
+.indie-wiki-banner-link-small {
+  display: inline-block;
+  font-size: 12px;
+  min-width: 180px;
+}
+.indie-wiki-banner-disabled {
+  color: #333;
+  cursor: default;
+}
+.indie-wiki-banner-disabled:hover {
+  text-decoration: none;
+}
+.indie-wiki-banner-hidden {
+  display: none;
+}


### PR DESCRIPTION
On the [Dota 2 Wiki](https://dota2.fandom.com/) in Dark Mode, if the "Visit Liquipedia Dota 2 Wiki" link is selected, it turns a pale blue color that does not contrast well with the pale blue Indie Wiki Buddy banner.

<img width="375" height="81" alt="Image" src="https://github.com/user-attachments/assets/fdd7db6a-73d7-4e9e-ad91-6bd0310c6531" />

This is being caused by some CSS that causes any selected link to turn that pale blue color. While this is fine in the site's body against their own dark background, it does not work in the Indie Wiki Buddy banner.

To fix this, I had initially set the text color in the banner to be `!important`, to prevent it being overridden by the wiki's own CSS. (I think there would be an argument for just making all of the banner styling `!important`, as the site's own CSS should not be able to override it, but for now I'm just doing this color since there is a known issue with it.)

However, I found that you can also fix this specific issue by just specifying that the same color should be used on `:focus` too. I've gone for this approach instead, to avoid unnecessary use of `!important`.

<img width="355" height="78" alt="image" src="https://github.com/user-attachments/assets/e595f322-9aff-4856-8b77-09b68eb29730" />
