### PR TITLE
Correct the Main Page of Fandom South Park Wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -10326,10 +10326,10 @@
   },
   {
     "id": "en-southpark",
-    "origins_label": "South Park Archives on Fandom",
+    "origins_label": "South Park Public Library on Fandom",
     "origins": [
       {
-        "origin": "South Park Archives on Fandom",
+        "origin": "South Park Public Library on Fandom",
         "origin_base_url": "southpark.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "South_Park_Public_Library"


### PR DESCRIPTION
The Main Page of the Fandom South Park Wiki is "[South Park Public Library](https://southpark.fandom.com/wiki/South_Park_Public_Library)", not "[South Park Archives](https://southpark.wiki.gg/wiki/South_Park_Archives)" like the independent wiki.

"[South Park Public Library](https://southpark.wiki.gg/wiki/South_Park_Public_Library)" is actually a content page on the independent South Park wiki, so the Main Page of the Fandom wiki was redirecting to a content page in error.