### PR TITLE
Don't re-analyze previously detected nodes on Brave search

### DIFF
--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -562,9 +562,7 @@ async function filterSearchResults(searchResults) {
       }
 
       const detectedContainer = searchResult.closest('.iwb-detected');
-      // For most engines, skip nested and previously-detected nodes.
-      // Brave is excluded because it frequently rewrites the DOM and needs reprocessing.
-      const skipDetectedResult = searchEngine !== 'brave' && !!detectedContainer && !detectedContainer.querySelector('.iwb-new-link');
+      const skipDetectedResult = !!detectedContainer && !detectedContainer.querySelector('.iwb-new-link');
 
       // Check that result isn't within another result.
       if (!skipDetectedResult) {


### PR DESCRIPTION
Fixes #1447.

From my testing, this additional restriction caused the freezes, and removing it doesn't actually cause any issues with the functionality of the extension.