### PR TITLE
Do not redirect Special Pages to BreezeWiki

### DIFF
--- a/background.js
+++ b/background.js
@@ -173,7 +173,7 @@ function redirectToBreezeWiki(storage, tabId, url) {
     }
   }
 
-  if (url.includes('fandom.com/wiki/') && !url.includes('fandom.com/wiki/Special:') && !url.includes('fandom=allow')) {
+  if (url.includes('fandom.com/wiki/') && !url.includes('fandom.com/wiki/Special:') && !url.includes('fandom.com/wiki/Spezial:') && !url.includes('fandom=allow')) {
     if (!(storage.breezewikiHost ?? null)) {
       fetch('https://bw.getindie.wiki/instances.json')
         .then((response) => {

--- a/background.js
+++ b/background.js
@@ -173,7 +173,7 @@ function redirectToBreezeWiki(storage, tabId, url) {
     }
   }
 
-  if (url.includes('fandom.com/wiki/') && !url.includes('fandom=allow')) {
+  if (url.includes('fandom.com/wiki/') && !url.includes('fandom.com/wiki/Special:') && !url.includes('fandom=allow')) {
     if (!(storage.breezewikiHost ?? null)) {
       fetch('https://bw.getindie.wiki/instances.json')
         .then((response) => {


### PR DESCRIPTION
## Problem
BreezeWiki is unable to display Special Pages from Fandom. If you do attempt to visit a Special Page using BreezeWiki, you instead get this error message:

> BreezeWiki wasn't able to load this page.
> 
> pagecannotexist: Namespace doesn't allow actual pages.

If "Automatically redirect Fandom to BreezeWiki" is enabled, this causes a very frustrating situation when using the search bar on Fandom, as the URL parameters are stripped in the redirect process, meaning that you land on an error page and lose your original search query.

For example, if you set "Automatically redirect Fandom to BreezeWiki", navigate to https://pokemon.fandom.com/wiki/Pok%C3%A9mon_Wiki?fandom=allow , then attempt to use the search bar, you will be redirected to https://breezewiki.com/pokemon/wiki/Special:Search

This is relevant to all special pages not just Special:Search (I originally noticed this when trying to check Special:Statistics on Fandom wikis), but that is the case that is most frustrating.

## Solution
I've simply excluded any URL including `fandom.com/wiki/Special:` from being redirected to BreezeWiki.

This assumes that the wiki is in English, as the Special Page namespace is localized in other languages. However, it appears that IWB only redirects Fandom wikis located at `fandom.com/wiki` to BreezeWiki anyway, so almost all of those wikis are going to be in English anyway. From my quick investigation, it seems like BreezeWiki doesn't support proxying wikis with languages in their path anyway (or if it does, I wasn't able to figure out what URL path to use), so this limitation appears to be on the BreezeWiki side, not IWB's.

However, there are a handful of non-English wikis located at `fandom.com/wiki` paths. IWB currently has three in its data:
* https://detektivconan.fandom.com/wiki/Detektiv_Conan_Wiki
* https://tokipona.fandom.com/wiki/lipu_lawa
* https://hlforever.fandom.com/wiki/%E9%A6%96%E9%A0%81
Of these three wikis, only Detektiv Conan Wiki does not use "Special:" for its Special Page namespace, instead using the German "Spezial:". As a result, I've also added a check for any URL including `fandom.com/wiki/Spezial:`.