### PR TITLE
Use ES modules for sharing common functions

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,6 +1,10 @@
-if (typeof importScripts !== 'undefined') {
-  importScripts('scripts/common-functions.js');
-}
+import { 
+  extensionAPI, 
+  commonFunctionMigrateToV3, 
+  commonFunctionFindMatchingSite, 
+  commonFunctionDecompressJSON,
+  commonFunctionGetNewURL,
+ } from "./scripts/common-functions.js";
 
 let cachedStorage = {};
 

--- a/background.js
+++ b/background.js
@@ -1,9 +1,9 @@
 import { 
-  extensionAPI, 
-  commonFunctionMigrateToV3, 
-  commonFunctionFindMatchingSite, 
-  commonFunctionDecompressJSON,
-  commonFunctionGetNewURL,
+  extensionAPI,
+  decompressJSON,
+  findMatchingSite,
+  getNewURL,
+  migrateToV3,
  } from "./scripts/common-functions.js";
 
 let cachedStorage = {};
@@ -124,7 +124,7 @@ extensionAPI.runtime.onInstalled.addListener(async (detail) => {
 
   // Temporary functions for 3.0 migration
   if (detail.reason === 'update') {
-    commonFunctionMigrateToV3();
+    migrateToV3();
   }
 });
 
@@ -226,17 +226,17 @@ async function main(url, tabId) {
 
   if ((storage.power ?? 'on') === 'on') {
     let crossLanguageSetting = storage.crossLanguage || 'off';
-    let matchingSite = await commonFunctionFindMatchingSite(url, crossLanguageSetting);
+    let matchingSite = await findMatchingSite(url, crossLanguageSetting);
 
     if (matchingSite) {
       // Get user's settings for the wiki
-      let settings = await commonFunctionDecompressJSON(storage.wikiSettings) || {};
+      let settings = await decompressJSON(storage.wikiSettings) || {};
       let id = matchingSite['id'];
       let siteSetting = settings[id] || storage.defaultWikiAction || 'alert';
 
       // Check if redirects are enabled for the site
       if (siteSetting === 'redirect') {
-        let newURL = commonFunctionGetNewURL(url, matchingSite);
+        let newURL = getNewURL(url, matchingSite);
 
         // Perform redirect
         extensionAPI.tabs.update(tabId, { url: newURL });

--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -29,6 +29,9 @@
   "web_accessible_resources": [
     {
       "resources": [
+        "scripts/common-functions.js",
+        "scripts/content-search-filtering.js",
+        "scripts/content-banners.js",
         "favicons/*",
         "data/sitesCA.json",
         "data/sitesDE.json",
@@ -59,7 +62,8 @@
     }
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -283,8 +287,7 @@
         "https://www.google.cat/search*"
       ],
       "js": [
-        "scripts/common-functions.js",
-        "scripts/content-search-filtering.js"
+        "scripts/content-search-filtering-importer.js"
       ],
       "css": [
         "css/content-search-filtering.css"
@@ -317,8 +320,7 @@
         "https://breezewiki.woodland.cafe/*"
       ],
       "js": [
-        "scripts/common-functions.js",
-        "scripts/content-banners.js"
+        "scripts/content-banners-importer.js"
       ],
       "css": [
         "css/content-banners.css"
@@ -348,7 +350,6 @@
         "https://breezewiki.woodland.cafe/*"
       ],
       "js": [
-        "scripts/common-functions.js",
         "scripts/content-breezewiki.js"
       ],
       "run_at": "document_end"
@@ -384,6 +385,6 @@
   "optional_host_permissions": [
     "https://*/*"
   ],
-  "minimum_chrome_version": "88",
+  "minimum_chrome_version": "131",
   "manifest_version": 3
 }

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -49,6 +49,9 @@
     }
   },
   "web_accessible_resources": [
+    "scripts/common-functions.js",
+    "scripts/content-search-filtering.js",
+    "scripts/content-banners.js",
     "favicons/*",
     "data/sitesCA.json",
     "data/sitesDE.json",
@@ -78,6 +81,7 @@
       "scripts/common-functions.js",
       "background.js"
     ],
+    "type": "module",
     "persistent": true
   },
   "content_scripts": [
@@ -107,8 +111,7 @@
         "https://breezewiki.woodland.cafe/*"
       ],
       "js": [
-        "scripts/common-functions.js",
-        "scripts/content-banners.js"
+        "scripts/content-banners-importer.js"
       ],
       "css": [
         "css/content-banners.css"
@@ -138,7 +141,6 @@
         "https://breezewiki.woodland.cafe/*"
       ],
       "js": [
-        "scripts/common-functions.js",
         "scripts/content-breezewiki.js"
       ],
       "run_at": "document_end"
@@ -364,8 +366,7 @@
         "https://www.google.cat/search*"
       ],
       "js": [
-        "scripts/common-functions.js",
-        "scripts/content-search-filtering.js"
+        "scripts/content-search-filtering-importer.js"
       ],
       "css": [
         "css/content-search-filtering.css"

--- a/pages/common-page-functions.js
+++ b/pages/common-page-functions.js
@@ -1,3 +1,5 @@
+import { extensionAPI } from "../scripts/common-functions.js";
+
 // Set setting toggle values on-load:
 extensionAPI.storage.sync.get({ 'notifications': 'on' }, (item) => {
   setNotifications(item.notifications, false);

--- a/pages/guide/guide.js
+++ b/pages/guide/guide.js
@@ -1,4 +1,4 @@
-const extensionAPI = typeof browser === "undefined" ? chrome : browser;
+import { extensionAPI } from "../../scripts/common-functions.js";
 
 // Somehow this has to be done manually
 document.querySelectorAll('[data-msg]').forEach(element => {

--- a/pages/guide/index.html
+++ b/pages/guide/index.html
@@ -164,6 +164,6 @@
     </div>
   </div>
 </body>
-<script type="text/javascript" src="guide.js"></script>
+<script type="module" src="guide.js"></script>
 
 </html>

--- a/pages/popup/index.html
+++ b/pages/popup/index.html
@@ -220,8 +220,7 @@
     </form>
   </div>
 </body>
-<script type="text/javascript" src="../../scripts/common-functions.js"></script>
-<script type="text/javascript" src="../common-page-functions.js"></script>
-<script type="text/javascript" src="popup.js"></script>
+<script type="module" src="../common-page-functions.js"></script>
+<script type="module" src="popup.js"></script>
 
 </html>

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -1,12 +1,12 @@
 import { 
   extensionAPI,
-  commonFunctionMigrateToV3,
-  commonFunctionGetSiteDataByDestination,
-  commonFunctionCompressJSON,
+  compressJSON,
+  getSiteDataByDestination,
+  migrateToV3,
  } from "../../scripts/common-functions.js";
 
 async function migrateData() {
-  commonFunctionMigrateToV3();
+  migrateToV3();
 }
 
 // Set power setting
@@ -115,11 +115,11 @@ document.addEventListener('DOMContentLoaded', () => {
       extensionAPI.storage.sync.set({ 'defaultWikiAction': document.options.defaultWikiAction.value })
 
       let wikiSettings = {};
-      const sites = await commonFunctionGetSiteDataByDestination();
+      const sites = await getSiteDataByDestination();
       sites.forEach((site) => {
         wikiSettings[site.id] = document.options.defaultWikiAction.value;
       });
-      extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+      extensionAPI.storage.sync.set({ 'wikiSettings': await compressJSON(wikiSettings) });
     });
   });
   document.querySelectorAll('[name="defaultSearchAction"]').forEach((el) => {
@@ -127,11 +127,11 @@ document.addEventListener('DOMContentLoaded', () => {
       extensionAPI.storage.sync.set({ 'defaultSearchAction': document.options.defaultSearchAction.value })
 
       let searchEngineSettings = {};
-      const sites = await commonFunctionGetSiteDataByDestination();
+      const sites = await getSiteDataByDestination();
       sites.forEach((site) => {
         searchEngineSettings[site.id] = document.options.defaultSearchAction.value;
       });
-      extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
+      extensionAPI.storage.sync.set({ 'searchEngineSettings': await compressJSON(searchEngineSettings) });
     });
   });
 });

--- a/pages/popup/popup.js
+++ b/pages/popup/popup.js
@@ -1,3 +1,10 @@
+import { 
+  extensionAPI,
+  commonFunctionMigrateToV3,
+  commonFunctionGetSiteDataByDestination,
+  commonFunctionCompressJSON,
+ } from "../../scripts/common-functions.js";
+
 async function migrateData() {
   commonFunctionMigrateToV3();
 }
@@ -108,7 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
       extensionAPI.storage.sync.set({ 'defaultWikiAction': document.options.defaultWikiAction.value })
 
       let wikiSettings = {};
-      sites = await commonFunctionGetSiteDataByDestination();
+      const sites = await commonFunctionGetSiteDataByDestination();
       sites.forEach((site) => {
         wikiSettings[site.id] = document.options.defaultWikiAction.value;
       });
@@ -120,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
       extensionAPI.storage.sync.set({ 'defaultSearchAction': document.options.defaultSearchAction.value })
 
       let searchEngineSettings = {};
-      sites = await commonFunctionGetSiteDataByDestination();
+      const sites = await commonFunctionGetSiteDataByDestination();
       sites.forEach((site) => {
         searchEngineSettings[site.id] = document.options.defaultSearchAction.value;
       });

--- a/pages/settings/index.html
+++ b/pages/settings/index.html
@@ -373,8 +373,7 @@
     </div>
   </div>
 </body>
-<script type="text/javascript" src="../../scripts/common-functions.js"></script>
-<script type="text/javascript" src="../common-page-functions.js"></script>
-<script type="text/javascript" src="settings.js"></script>
+<script type="module" src="../common-page-functions.js"></script>
+<script type="module" src="settings.js"></script>
 
 </html>

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -1,10 +1,10 @@
 import { 
   extensionAPI, 
   camelCaseJoin, 
-  commonFunctionMigrateToV3,
-  commonFunctionCompressJSON,
-  commonFunctionDecompressJSON,
-  commonFunctionGetSiteDataByDestination,
+  compressJSON,
+  decompressJSON,
+  migrateToV3,
+  getSiteDataByDestination,
 } from "../../scripts/common-functions.js";
 
 let sites = [];
@@ -47,9 +47,9 @@ function createRadioButton(redirectEntry, action, category) {
   const settingsType = `${category}Settings`;
   radioButton.addEventListener('click', () => {
     extensionAPI.storage.sync.get(settingsType, async (response) => {
-      const settings = await commonFunctionDecompressJSON(response[settingsType]);
+      const settings = await decompressJSON(response[settingsType]);
       settings[redirectID] = action;
-      extensionAPI.storage.sync.set({ [settingsType]: await commonFunctionCompressJSON(settings) });
+      extensionAPI.storage.sync.set({ [settingsType]: await compressJSON(settings) });
     });
   });
 
@@ -58,7 +58,7 @@ function createRadioButton(redirectEntry, action, category) {
 
 // Populate settings and toggles
 async function loadOptions(lang, textFilter = '') {
-  sites = await commonFunctionGetSiteDataByDestination();
+  sites = await getSiteDataByDestination();
   textFilter = textFilter.toLocaleLowerCase();
 
   // Sort sites alphabetically by destination
@@ -87,8 +87,8 @@ async function loadOptions(lang, textFilter = '') {
   extensionAPI.storage.local.get((localStorage) => {
     extensionAPI.storage.sync.get(async (syncStorage) => {
       const storage = { ...syncStorage, ...localStorage };
-      const wikiSettings = await commonFunctionDecompressJSON(storage.wikiSettings ?? {});
-      const searchEngineSettings = await commonFunctionDecompressJSON(storage.searchEngineSettings ?? {});
+      const wikiSettings = await decompressJSON(storage.wikiSettings ?? {});
+      const searchEngineSettings = await decompressJSON(storage.searchEngineSettings ?? {});
       const defaultWikiAction = storage.defaultWikiAction ?? null;
       const defaultSearchAction = storage.defaultSearchAction ?? null;
 
@@ -105,7 +105,7 @@ async function loadOptions(lang, textFilter = '') {
             toggles[i].checked = true;
             settings[toggles[i].getAttribute('data-wiki-key')] = action;
           }
-          extensionAPI.storage.sync.set({ [settingsType]: await commonFunctionCompressJSON(settings) });
+          extensionAPI.storage.sync.set({ [settingsType]: await compressJSON(settings) });
         });
       }
 
@@ -342,7 +342,7 @@ document.getElementById('powerCheckbox').addEventListener('change', () => {
 });
 
 async function migrateData() {
-  commonFunctionMigrateToV3();
+  migrateToV3();
 }
 
 // Main function that runs on-load

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -1,3 +1,12 @@
+import { 
+  extensionAPI, 
+  camelCaseJoin, 
+  commonFunctionMigrateToV3,
+  commonFunctionCompressJSON,
+  commonFunctionDecompressJSON,
+  commonFunctionGetSiteDataByDestination,
+} from "../../scripts/common-functions.js";
+
 let sites = [];
 
 // Clear wiki toggles
@@ -7,7 +16,7 @@ function resetOptions() {
 
    // Need to create a copy first, because the children change while iterating
   const toggleTableRows = [...toggleTableBody.children];
-  for(el of toggleTableRows) {
+  for(const el of toggleTableRows) {
     if(el.classList?.contains('site-container')) {
       el.remove();
     }
@@ -225,7 +234,7 @@ async function loadOptions(lang, textFilter = '') {
           inputSearchEngineReplace, 
           inputSearchEngineHide
         ];
-        for(cellContent of rowCells) {
+        for(const cellContent of rowCells) {
           const cell = document.createElement("td");
           cell.appendChild(cellContent);
           siteRow.appendChild(cell);

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -33,7 +33,7 @@ export function camelCaseJoin(stringArray) {
 }
 
 /** @param {string} value */
-export async function commonFunctionDecompressJSON(value) {
+export async function decompressJSON(value) {
   // Check if value is base64 encoded:
   if (BASE64REGEX.test(value)) {
     // Decode into blob
@@ -55,7 +55,7 @@ export async function commonFunctionDecompressJSON(value) {
   }
 }
 /** @param {string} value */
-export async function commonFunctionCompressJSON(value) {
+export async function compressJSON(value) {
   const stream = new Blob([JSON.stringify(value)], {
     type: 'application/json',
   }).stream();
@@ -82,7 +82,7 @@ export async function commonFunctionCompressJSON(value) {
  * Load wiki data objects, with each destination having its own object
  * @returns {Promise<SiteInfo[]>}
  */
-export async function commonFunctionGetSiteDataByDestination() {
+export async function getSiteDataByDestination() {
   var sites = [];
   let promises = [];
   for (let i = 0; i < LANGS.length; i++) {
@@ -152,7 +152,7 @@ let _siteDataByOrigin;
  * Load wiki data objects, with each origin having its own object
  * @returns {Promise<SiteData[]>}
  */
-export async function commonFunctionGetSiteDataByOrigin() {
+export async function getSiteDataByOrigin() {
   if (_siteDataByOrigin === undefined) {
     let resolve;
     _siteDataByOrigin = new Promise(_resolve => resolve = _resolve);
@@ -171,10 +171,10 @@ export async function commonFunctionGetSiteDataByOrigin() {
  * @param {string} crossLanguageSetting
  * @param {boolean} dest
  */
-export async function commonFunctionFindMatchingSite(site, crossLanguageSetting, dest = false) {
+export async function findMatchingSite(site, crossLanguageSetting, dest = false) {
   let base_url_key = dest ? 'destination_base_url' : 'origin_base_url';
 
-  let sites = await commonFunctionGetSiteDataByOrigin();
+  let sites = await getSiteDataByOrigin();
 
   let matchingSites = [];
   if (crossLanguageSetting === 'on') {
@@ -205,7 +205,7 @@ export async function commonFunctionFindMatchingSite(site, crossLanguageSetting,
  * @param {string} originURL
  * @param {SiteData} matchingSite
  */
-export function commonFunctionGetOriginArticle(originURL, matchingSite) {
+export function getOriginArticle(originURL, matchingSite) {
   let url = new URL('https://' + originURL.replace(/.*https?:\/\//, ''));
   let article = String(url.pathname).split(matchingSite['origin_content_path'])[1] || '';
 
@@ -222,7 +222,7 @@ export function commonFunctionGetOriginArticle(originURL, matchingSite) {
  * @param {SiteData} matchingSite
  * @param {string} article
  */
-export function commonFunctionGetDestinationArticle(matchingSite, article) {
+export function getDestinationArticle(matchingSite, article) {
   return matchingSite['destination_content_prefix'] + article + matchingSite['destination_content_suffix'];
 }
 
@@ -254,12 +254,12 @@ export function getQueryParams(originURL) {
  * @param {string} originURL
  * @param {SiteData} matchingSite
  */
-export function commonFunctionGetNewURL(originURL, matchingSite) {
+export function getNewURL(originURL, matchingSite) {
   // Get article name from the end of the URL;
   // We can't just take the last part of the path due to subpages;
   // Instead, we take everything after the wiki's base URL + content path
-  let originArticle = commonFunctionGetOriginArticle(originURL, matchingSite);
-  let destinationArticle = commonFunctionGetDestinationArticle(matchingSite, originArticle);
+  let originArticle = getOriginArticle(originURL, matchingSite);
+  let destinationArticle = getDestinationArticle(matchingSite, originArticle);
 
   // Set up URL to redirect user to based on wiki platform
   let newURL = '';
@@ -303,7 +303,7 @@ export function commonFunctionGetNewURL(originURL, matchingSite) {
 }
 
 /** Temporary function to migrate user data to IWB version 3.0+ */
-export async function commonFunctionMigrateToV3() {
+export async function migrateToV3() {
   await extensionAPI.storage.sync.get(async (storage) => {
     if (!storage.v3migration) {
       let defaultWikiAction = storage.defaultWikiAction || 'alert';
@@ -332,10 +332,10 @@ export async function commonFunctionMigrateToV3() {
       extensionAPI.storage.sync.remove('defaultSearchFilterSettings');
 
       // Migrate wiki settings to new searchEngineSettings and wikiSettings objects
-      const sites = await commonFunctionGetSiteDataByOrigin();
+      const sites = await getSiteDataByOrigin();
       let siteSettings = storage.siteSettings || {};
-      let searchEngineSettings = await commonFunctionDecompressJSON(storage.searchEngineSettings || {});
-      let wikiSettings = await commonFunctionDecompressJSON(storage.wikiSettings) || {};
+      let searchEngineSettings = await decompressJSON(storage.searchEngineSettings || {});
+      let wikiSettings = await decompressJSON(storage.wikiSettings) || {};
 
       sites.forEach((site) => {
         if (!searchEngineSettings[site.id]) {
@@ -355,8 +355,8 @@ export async function commonFunctionMigrateToV3() {
         }
       });
 
-      extensionAPI.storage.sync.set({ 'searchEngineSettings': await commonFunctionCompressJSON(searchEngineSettings) });
-      extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+      extensionAPI.storage.sync.set({ 'searchEngineSettings': await compressJSON(searchEngineSettings) });
+      extensionAPI.storage.sync.set({ 'wikiSettings': await compressJSON(wikiSettings) });
 
       // Remove old object:
       extensionAPI.storage.sync.remove('siteSettings');

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -245,7 +245,7 @@ export function encodeArticleTitle(articleTitle) {
  * Get query parameters from a URL
  * @param {string} originURL
  */
-export function getQueryParams(originURL) {
+function getQueryParams(originURL) {
   let url = new URL('https://' + originURL.replace(/.*https?:\/\//, ''));
   return url.search || '';
 }

--- a/scripts/common-functions.js
+++ b/scripts/common-functions.js
@@ -1,6 +1,6 @@
-var LANGS = ["CA", "DE", "EN", "ES", "FI", "FR", "HR", "HU", "IT", "JA", "KO", "LZH", "NL", "PL", "PT", "RU", "SV", "TH", "TOK", "TR", "UK", "ZH"];
-var BASE64REGEX = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-const extensionAPI = typeof browser === "undefined" ? chrome : browser;
+export const extensionAPI = typeof browser === "undefined" ? chrome : browser;
+const LANGS = ["CA", "DE", "EN", "ES", "FI", "FR", "HR", "HU", "IT", "JA", "KO", "LZH", "NL", "PL", "PT", "RU", "SV", "TH", "TOK", "TR", "UK", "ZH"];
+const BASE64REGEX = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 
 /** @param {string} str */
 function b64decode(str) {
@@ -18,7 +18,7 @@ function b64decode(str) {
  * @param {string[]} stringArray
  * @returns {string}
  */
-function camelCaseJoin(stringArray) {
+export function camelCaseJoin(stringArray) {
   let outputString = "";
   for(let i = 0; i < stringArray.length; i++)
   {
@@ -33,7 +33,7 @@ function camelCaseJoin(stringArray) {
 }
 
 /** @param {string} value */
-async function commonFunctionDecompressJSON(value) {
+export async function commonFunctionDecompressJSON(value) {
   // Check if value is base64 encoded:
   if (BASE64REGEX.test(value)) {
     // Decode into blob
@@ -55,7 +55,7 @@ async function commonFunctionDecompressJSON(value) {
   }
 }
 /** @param {string} value */
-async function commonFunctionCompressJSON(value) {
+export async function commonFunctionCompressJSON(value) {
   const stream = new Blob([JSON.stringify(value)], {
     type: 'application/json',
   }).stream();
@@ -82,7 +82,7 @@ async function commonFunctionCompressJSON(value) {
  * Load wiki data objects, with each destination having its own object
  * @returns {Promise<SiteInfo[]>}
  */
-async function commonFunctionGetSiteDataByDestination() {
+export async function commonFunctionGetSiteDataByDestination() {
   var sites = [];
   let promises = [];
   for (let i = 0; i < LANGS.length; i++) {
@@ -152,7 +152,7 @@ let _siteDataByOrigin;
  * Load wiki data objects, with each origin having its own object
  * @returns {Promise<SiteData[]>}
  */
-async function commonFunctionGetSiteDataByOrigin() {
+export async function commonFunctionGetSiteDataByOrigin() {
   if (_siteDataByOrigin === undefined) {
     let resolve;
     _siteDataByOrigin = new Promise(_resolve => resolve = _resolve);
@@ -171,7 +171,7 @@ async function commonFunctionGetSiteDataByOrigin() {
  * @param {string} crossLanguageSetting
  * @param {boolean} dest
  */
-async function commonFunctionFindMatchingSite(site, crossLanguageSetting, dest = false) {
+export async function commonFunctionFindMatchingSite(site, crossLanguageSetting, dest = false) {
   let base_url_key = dest ? 'destination_base_url' : 'origin_base_url';
 
   let sites = await commonFunctionGetSiteDataByOrigin();
@@ -205,7 +205,7 @@ async function commonFunctionFindMatchingSite(site, crossLanguageSetting, dest =
  * @param {string} originURL
  * @param {SiteData} matchingSite
  */
-function commonFunctionGetOriginArticle(originURL, matchingSite) {
+export function commonFunctionGetOriginArticle(originURL, matchingSite) {
   let url = new URL('https://' + originURL.replace(/.*https?:\/\//, ''));
   let article = String(url.pathname).split(matchingSite['origin_content_path'])[1] || '';
 
@@ -222,14 +222,14 @@ function commonFunctionGetOriginArticle(originURL, matchingSite) {
  * @param {SiteData} matchingSite
  * @param {string} article
  */
-function commonFunctionGetDestinationArticle(matchingSite, article) {
+export function commonFunctionGetDestinationArticle(matchingSite, article) {
   return matchingSite['destination_content_prefix'] + article + matchingSite['destination_content_suffix'];
 }
 
 /**
  * @param {string} articleTitle
  */
-function encodeArticleTitle(articleTitle) {
+export function encodeArticleTitle(articleTitle) {
   // We decode + encode to ensure we don't double-encode,
   // in the event a string is already encoded.
   // We wrap in a try-catch as decoding can sometimes fail if destination article
@@ -245,7 +245,7 @@ function encodeArticleTitle(articleTitle) {
  * Get query parameters from a URL
  * @param {string} originURL
  */
-function getQueryParams(originURL) {
+export function getQueryParams(originURL) {
   let url = new URL('https://' + originURL.replace(/.*https?:\/\//, ''));
   return url.search || '';
 }
@@ -254,7 +254,7 @@ function getQueryParams(originURL) {
  * @param {string} originURL
  * @param {SiteData} matchingSite
  */
-function commonFunctionGetNewURL(originURL, matchingSite) {
+export function commonFunctionGetNewURL(originURL, matchingSite) {
   // Get article name from the end of the URL;
   // We can't just take the last part of the path due to subpages;
   // Instead, we take everything after the wiki's base URL + content path
@@ -303,7 +303,7 @@ function commonFunctionGetNewURL(originURL, matchingSite) {
 }
 
 /** Temporary function to migrate user data to IWB version 3.0+ */
-async function commonFunctionMigrateToV3() {
+export async function commonFunctionMigrateToV3() {
   await extensionAPI.storage.sync.get(async (storage) => {
     if (!storage.v3migration) {
       let defaultWikiAction = storage.defaultWikiAction || 'alert';
@@ -368,7 +368,7 @@ async function commonFunctionMigrateToV3() {
 }
 
 /** @param {Node} element */
-function isAnchor(element) {
+export function isAnchor(element) {
   if (!(element instanceof HTMLElement)) return false;
   return element.tagName && element.tagName.toLowerCase() === 'a';
 }

--- a/scripts/content-banners-importer.js
+++ b/scripts/content-banners-importer.js
@@ -1,0 +1,12 @@
+// Static imports do not work in content scripts, but dynamic imports do.
+// By dynamically importing the entire main script from web_accessible_resources,
+// the main script can successfully resolve its own static imports.
+//
+// Based on https://stackoverflow.com/a/53033388
+
+const extensionAPI = typeof browser === "undefined" ? chrome : browser;
+
+(async () => {
+  const src = extensionAPI.runtime.getURL('scripts/content-banners.js');
+  await import(src);
+})();

--- a/scripts/content-banners.js
+++ b/scripts/content-banners.js
@@ -1,3 +1,12 @@
+import { 
+  extensionAPI, 
+  commonFunctionCompressJSON, 
+  commonFunctionDecompressJSON, 
+  commonFunctionGetSiteDataByOrigin, 
+  commonFunctionGetNewURL,
+  commonFunctionFindMatchingSite,
+} from "./common-functions.js";
+
 const breezewikiRegex = /breezewiki\.com$|antifandom\.com$|bw\.artemislena\.eu$|breezewiki\.catsarch\.com$|breezewiki\.esmailelbob\.xyz$|breezewiki\.frontendfriendly\.xyz$|bw\.hamstro\.dev$|breeze\.hostux\.net$|breezewiki\.hyperreal\.coffee$|breeze\.mint\.lgbt$|breezewiki\.nadeko\.net$|nerd\.whatever\.social$|breeze\.nohost\.network$|z\.opnxng\.com$|bw\.projectsegfau\.lt$|breezewiki\.pussthecat\.org$|bw\.vern\.cc$|breeze\.whateveritworks\.org$|breezewiki\.woodland\.cafe$/;
 const currentURL = new URL(document.location);
 
@@ -20,7 +29,7 @@ function processBreezeWikiBanner(storage) {
     // Extract article from URL
     const subdomain = currentURL.hostname.split(".")[0];
     const article = currentURL.toString().split('fandom.com/wiki/')[1].replaceAll('%20', '_');
-    breezewikiHost = '';
+    let breezewikiHost = '';
     if (!(storage.breezewikiHost ?? null)) {
       fetch('https://bw.getindie.wiki/instances.json')
         .then((response) => {

--- a/scripts/content-banners.js
+++ b/scripts/content-banners.js
@@ -1,10 +1,10 @@
 import { 
-  extensionAPI, 
-  commonFunctionCompressJSON, 
-  commonFunctionDecompressJSON, 
-  commonFunctionGetSiteDataByOrigin, 
-  commonFunctionGetNewURL,
-  commonFunctionFindMatchingSite,
+  extensionAPI,
+  compressJSON,
+  decompressJSON,
+  getSiteDataByOrigin,
+  getNewURL,
+  findMatchingSite,
 } from "./common-functions.js";
 
 const breezewikiRegex = /breezewiki\.com$|antifandom\.com$|bw\.artemislena\.eu$|breezewiki\.catsarch\.com$|breezewiki\.esmailelbob\.xyz$|breezewiki\.frontendfriendly\.xyz$|bw\.hamstro\.dev$|breeze\.hostux\.net$|breezewiki\.hyperreal\.coffee$|breeze\.mint\.lgbt$|breezewiki\.nadeko\.net$|nerd\.whatever\.social$|breeze\.nohost\.network$|z\.opnxng\.com$|bw\.projectsegfau\.lt$|breezewiki\.pussthecat\.org$|bw\.vern\.cc$|breeze\.whateveritworks\.org$|breezewiki\.woodland\.cafe$/;
@@ -132,9 +132,9 @@ function displayRedirectBanner(newUrl, id, destinationName, destinationLanguage,
   bannerControls.appendChild(bannerRestoreLink);
   bannerRestoreLink.onclick = function (e) {
     extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
-      let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
+      let wikiSettings = await decompressJSON(response.wikiSettings);
       wikiSettings[id] = 'alert';
-      extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+      extensionAPI.storage.sync.set({ 'wikiSettings': await compressJSON(wikiSettings) });
       e.target.textContent = '✓ ' + extensionAPI.i18n.getMessage('bannerRestoreDone');
       e.target.classList.add('indie-wiki-banner-disabled');
       bannerControls.querySelector('.indie-wiki-banner-redirect').textContent = '↪ ' + extensionAPI.i18n.getMessage('bannerRedirect');
@@ -154,9 +154,9 @@ function displayRedirectBanner(newUrl, id, destinationName, destinationLanguage,
   bannerControls.appendChild(bannerDisableLink);
   bannerDisableLink.onclick = function (e) {
     extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
-      let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
+      let wikiSettings = await decompressJSON(response.wikiSettings);
       wikiSettings[id] = 'disabled';
-      extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+      extensionAPI.storage.sync.set({ 'wikiSettings': await compressJSON(wikiSettings) });
       e.target.textContent = '✓ ' + extensionAPI.i18n.getMessage('bannerDisableDone');
       e.target.classList.add('indie-wiki-banner-disabled');
       bannerControls.querySelector('.indie-wiki-banner-restore').textContent = '⎌ ' + extensionAPI.i18n.getMessage('bannerRestore');
@@ -174,9 +174,9 @@ function displayRedirectBanner(newUrl, id, destinationName, destinationLanguage,
   bannerControls.appendChild(bannerRedirectLink);
   bannerRedirectLink.onclick = function (e) {
     extensionAPI.storage.sync.get({ 'wikiSettings': {} }, async (response) => {
-      let wikiSettings = await commonFunctionDecompressJSON(response.wikiSettings);
+      let wikiSettings = await decompressJSON(response.wikiSettings);
       wikiSettings[id] = 'redirect';
-      extensionAPI.storage.sync.set({ 'wikiSettings': await commonFunctionCompressJSON(wikiSettings) });
+      extensionAPI.storage.sync.set({ 'wikiSettings': await compressJSON(wikiSettings) });
       e.target.textContent = '✓ ' + extensionAPI.i18n.getMessage('bannerRedirectDone');
       e.target.classList.add('indie-wiki-banner-disabled');
       bannerControls.querySelector('.indie-wiki-banner-disable').classList.add('indie-wiki-banner-hidden');
@@ -280,14 +280,14 @@ function main() {
           }
         }
 
-        commonFunctionGetSiteDataByOrigin().then(async sites => {
+        getSiteDataByOrigin().then(async sites => {
           let crossLanguageSetting = storage.crossLanguage || 'off';
-          let matchingSite = await commonFunctionFindMatchingSite(origin, crossLanguageSetting);
+          let matchingSite = await findMatchingSite(origin, crossLanguageSetting);
           if (matchingSite) {
             // Get user's settings for the wiki
             let id = matchingSite['id'];
             let siteSetting = 'alert';
-            let wikiSettings = await commonFunctionDecompressJSON(storage.wikiSettings || {});
+            let wikiSettings = await decompressJSON(storage.wikiSettings || {});
             if (wikiSettings[id]) {
               siteSetting = wikiSettings[id];
             } else if (storage.defaultWikiAction) {
@@ -296,7 +296,7 @@ function main() {
 
             // Notify if enabled for the wiki:
             if (siteSetting === 'alert') {
-              let newURL = commonFunctionGetNewURL(origin, matchingSite);
+              let newURL = getNewURL(origin, matchingSite);
 
               // When head elem is loaded, notify that another wiki is available
               const docObserver = new MutationObserver((mutations, mutationInstance) => {

--- a/scripts/content-search-filtering-importer.js
+++ b/scripts/content-search-filtering-importer.js
@@ -1,0 +1,12 @@
+// Static imports do not work in content scripts, but dynamic imports do.
+// By dynamically importing the entire main script from web_accessible_resources,
+// the main script can successfully resolve its own static imports.
+//
+// Based on https://stackoverflow.com/a/53033388
+
+const extensionAPI = typeof browser === "undefined" ? chrome : browser;
+
+(async () => {
+  const src = extensionAPI.runtime.getURL('scripts/content-search-filtering.js');
+  await import(src);
+})();

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -1,11 +1,11 @@
 import { 
-  extensionAPI, 
-  commonFunctionDecompressJSON, 
-  commonFunctionFindMatchingSite,
-  commonFunctionGetDestinationArticle,
-  commonFunctionGetNewURL,
-  commonFunctionGetOriginArticle,
-  commonFunctionGetSiteDataByOrigin,
+  extensionAPI,
+  decompressJSON,
+  findMatchingSite,
+  getDestinationArticle,
+  getNewURL,
+  getOriginArticle,
+  getSiteDataByOrigin,
   isAnchor,
  } from './common-functions.js';
 
@@ -103,9 +103,9 @@ function getClosestBackgroundColor(element) {
  * @param {string} link
  */
 function replaceSearchResult(searchResultContainer, wikiInfo, link) {
-  let originArticle = commonFunctionGetOriginArticle(link, wikiInfo);
-  let destinationArticle = commonFunctionGetDestinationArticle(wikiInfo, originArticle);
-  let newURL = commonFunctionGetNewURL(link, wikiInfo);
+  let originArticle = getOriginArticle(link, wikiInfo);
+  let destinationArticle = getDestinationArticle(wikiInfo, originArticle);
+  let newURL = getNewURL(link, wikiInfo);
 
   if (searchResultContainer && !searchResultContainer.querySelector('.iwb-new-link') && !searchResultContainer.querySelector('.iwb-detected')) {
     searchResultContainer.classList.add('iwb-detected');
@@ -499,8 +499,8 @@ function filterSearchResult(wikiInfo, anchorElement) {
     if (searchResultContainer) {
       // If this page from the non-indie wiki is the same as a re-ordered page, filter it out
       let searchResultLink = anchorElement.getAttribute('data-iwb-href') || anchorElement.href;
-      let originArticle = commonFunctionGetOriginArticle(searchResultLink, wikiInfo);
-      let destinationArticle = commonFunctionGetDestinationArticle(wikiInfo, originArticle);
+      let originArticle = getOriginArticle(searchResultLink, wikiInfo);
+      let destinationArticle = getDestinationArticle(wikiInfo, originArticle);
 
       const destinationArticleDecoded = decodeURI(destinationArticle);
       const destinationArticleBase = destinationArticleDecoded.replace(/_\([^/]*\)$/, '');
@@ -608,7 +608,7 @@ async function filterSearchResults(searchResults) {
           searchResultContainer.classList.add('iwb-detected');
 
           // Handle source -> destination filtering, i.e. non-indie/commercial wikis
-          let matchingNonIndieWiki = await commonFunctionFindMatchingSite(searchResultLink, crossLanguageSetting);
+          let matchingNonIndieWiki = await findMatchingSite(searchResultLink, crossLanguageSetting);
           if (matchingNonIndieWiki) {
             // Site found in db, process search result
             console.debug('Indie Wiki Buddy: Filtering search result:', searchResultLink);
@@ -624,7 +624,7 @@ async function filterSearchResults(searchResults) {
             });
           } else {
             // handle destination -> source, i.e. indie wikis
-            let matchingIndieWiki = await commonFunctionFindMatchingSite(searchResultLink, crossLanguageSetting, true);
+            let matchingIndieWiki = await findMatchingSite(searchResultLink, crossLanguageSetting, true);
             if (matchingIndieWiki) {
               console.debug('Indie Wiki Buddy: Found indie wiki for search result:', searchResultLink);
               const cacheInfo = {
@@ -935,7 +935,7 @@ async function decompressStorage(storage) {
   await Promise.all(
     compressedKeys.map(async key => {
       if (storage[key]) {
-        storage[key] = await commonFunctionDecompressJSON(storage[key]);
+        storage[key] = await decompressJSON(storage[key]);
       }
     })
   );
@@ -972,7 +972,7 @@ function processSearchEngine(_searchEngine) {
 }
 
 // fill cache
-void commonFunctionGetSiteDataByOrigin();
+void getSiteDataByOrigin();
 
 // Figure out which search engine we're on
 if (currentURL.hostname.includes('www.google.')) {

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -1,6 +1,17 @@
-/// <reference lib="esnext" />
-/// <reference path="common-functions.js" />
-// @ts-check
+import { 
+  extensionAPI, 
+  commonFunctionDecompressJSON, 
+  commonFunctionFindMatchingSite,
+  commonFunctionGetDestinationArticle,
+  commonFunctionGetNewURL,
+  commonFunctionGetOriginArticle,
+  commonFunctionGetSiteDataByOrigin,
+  isAnchor,
+ } from './common-functions.js';
+
+/**
+ * @typedef {import('./common-functions').SiteData} SiteData
+ */
 
 const currentURL = new URL(document.location.href);
 let hiddenWikisRevealed = {};

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { 
   extensionAPI,
   decompressJSON,


### PR DESCRIPTION
Previously, common functions were shared by just providing them alongside JS files that reuse their methods. I have changed these functions to instead be shared via ESM import and export.

Depending on the type of script, enabling ESM imports/exports is done differently.
* For page scripts, this simply requires specifying `type="module"` on the `<script>` tag that adds them.
* For the background script, this simply requires specifying `"type": "module"` on the `background` object in the `manifest.json` file.
* For content scripts, static ESM imports are not supported, so a more complex workaround is required.

In content scripts, static ESM imports are not available, but dynamic imports are. If you dynamically import a JS file that uses static imports, those imports are also resolved with the dynamic import, indirectly allowing static imports to be used. If you make `common-functions.js` and the content script itself both `web_accessible_resources`, you can make a script to dynamically import the content script the registered `content_script`, and the imports can be resolved successfully. This [Stack Overflow answer](https://stackoverflow.com/a/53033388) explains the workaround that I implemented to allow ESM imports in content scripts.

As noted in that Stack Overflow answer, due to https://crbug.com/352364581 sites were able to block this dynamic import workaround via their own service workers. That Chrome bug was fixed in Chrome 131, so is no longer a concern. As a result, I've bumped the minimum supported Chrome version up to 131. (I did not do any kind of analysis of whether any of the sites that IWB content scripts run on are attempting to exploit that bug in older Chrome versions, but I figure it's best to be safe and ensure the bug fix is present when using these dynamic imports.) Chrome 131 was released in October 2024, so I don't think it's unreasonable to expect users to have upgraded to at least that version — the current minimum Chrome version is 88, which was released in November 2020 (for contrast, the minimum Gecko version is 113, which was released in May 2023).

The `type` field in `manifest.json`'s `background` object was [first supported](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_compatibility) in Chrome 92 and Firefox 112, so even if that bug isn't a concern, the minimum Chrome version would need to be bumped to at least 92 (released July 2021) to support this change.

## Benefits

This is something I've been wanting to implement for a long time, but have never really been able to figure out how to make it work. That Stack Overflow answer gave me the last missing piece I needed to put everything together.

One of my main hopes of a benefit of this change is to facilitate writing unit tests, which otherwise would be tricky to write when individual functions are implicitly depending on other files being loaded into the same global scope.

The other is that it better supports configuring linting for this repo. I have tried running a linter over the codebase, but all of the common functions being considered undefined makes it harder to find other errors. And I don't actually want to disable the `no-undef` rule, as there are in fact non-false positive cases of undefined variables being read (such as `host` being referenced without ever being defined in one instance in `content-banners.js`).

There's also no longer the namespace pollution concern, so the common functions no longer need to be prefixed with `commonFunction`.