### PR TITLE
Redirect Neoseeker MTG wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -7229,11 +7229,17 @@
   },
   {
     "id": "en-magicthegathering",
-    "origins_label": "Magic: The Gathering Fandom Wiki",
+    "origins_label": "Magic: The Gathering Fandom & Neoseeker Wikis",
     "origins": [
       {
         "origin": "Magic: The Gathering Fandom Wiki",
         "origin_base_url": "mtg.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Main_Page"
+      },
+      {
+        "origin": "Magic: The Gathering Wiki - Neoseeker",
+        "origin_base_url": "mtg.neoseeker.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Main_Page"
       }


### PR DESCRIPTION
Add the Neoseeker Magic the Gathering wiki as an additional origin for the MTG Wiki.