### PR TITLE
Add redirect from hyblock.fandom.com to existing indie wiki

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -5918,7 +5918,13 @@
         "origin_base_url": "skyblock.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Hypixel_SkyBlock_Wiki"
-      }
+      },
+      {
+        "origin": "Hyblock Fandom Wiki",
+        "origin_base_url": "hyblock.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Hypixel_Skyblock_Wiki"
+      },
     ],
     "destination": "Hypixel SkyBlock Wiki",
     "destination_base_url": "hypixelskyblock.minecraft.wiki",


### PR DESCRIPTION
Appears to be an old abandoned wiki, but might as well.