### PR TITLE
Update Item Asylum Wiki info

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -6273,7 +6273,7 @@
       }
     ],
     "destination": "Item Asylum Wiki",
-    "destination_base_url": "itemasylum.miraheze.org",
+    "destination_base_url": "itemasylum.wiki",
     "destination_platform": "mediawiki",
     "destination_icon": "itemasylumwiki.png",
     "destination_main_page": "Item_Asylum_Wiki",


### PR DESCRIPTION
Changing itemasylum.miraheze.org to itemasylum.wiki 
Also please update itemasylumwiki.png to this:
<img width="48" height="48" alt="itemasylumwiki" src="https://github.com/user-attachments/assets/ba602220-9f07-4fa7-a6a0-ac9c977109f2" />
