### PR TITLE
Adding redirect to Poupedia

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -9881,13 +9881,19 @@
   },
   {
     "id": "en-pou",
-    "origins_label": "Pou Fandom Wiki",
+    "origins_label": "Pou Fandom Wikis",
     "origins": [
       {
         "origin": "Pou Fandom Wiki",
         "origin_base_url": "pou.fandom.com",
         "origin_content_path": "/wiki/",
         "origin_main_page": "Pou_Wiki"
+      },
+      {
+        "origin": "Simple English Pou Fandom Wiki",
+        "origin_base_url": "simple-english-pou.fandom.com",
+        "origin_content_path": "/wiki/",
+        "origin_main_page": "Simple_English_Pou_Wiki"
       }
     ],
     "destination": "Poupedia",


### PR DESCRIPTION
Basically, someone is trying to recreate the Pou Fandom Wiki (which closed a year ago), and I would like to redirect it to Poupedia since the Fandom wiki has inferior quality and is more basic (as if we're talking about a Simple English wiki like Wikipedia for example); Poupedia is already considered to be a complete wiki.