### PR TITLE
Update lgbtqia+ wiki destination

### DIFF
--- a/data/sitesEN.json
+++ b/data/sitesEN.json
@@ -7341,12 +7341,13 @@
       }
     ],
     "destination": "LGBTQIA+ Wiki",
-    "destination_base_url": "new.lgbtqia.wiki",
+    "destination_base_url": "lgbtqia.wiki",
     "destination_platform": "mediawiki",
     "destination_icon": "lgbtqiawiki.png",
     "destination_main_page": "Main_Page",
-    "destination_search_path": "/w139/index.php",
-    "destination_content_path": "/wiki/"
+    "destination_search_path": "/w/index.php",
+    "destination_content_path": "/wiki/",
+    "destination_host": "Miraheze"
   },
   {
     "id": "en-libraryofruina",


### PR DESCRIPTION
Resolves #1573 
This wiki is [moving to Miraheze](https://new.lgbtqia.wiki/wiki/User:VDT/News/10.04.26), the old destination wiki is expected to be closed in September